### PR TITLE
Restructure outputs/ as mesh/material+pattern/view/sample hierarchy

### DIFF
--- a/cloth_pipeline/dataset/render_loop.py
+++ b/cloth_pipeline/dataset/render_loop.py
@@ -21,6 +21,9 @@ from cloth_pipeline.paths import (
     MESHES_DIR,
     METADATA_PATH,
     NORMALS_DIR,
+    PBR_ALBEDO_DIR,
+    PBR_NORMAL_DIR,
+    PBR_ROUGHNESS_DIR,
     RENDERS_DIR,
     ensure_dataset_stage_dirs,
     ensure_front_preview_dir,
@@ -140,10 +143,13 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
 
     existing = sum(
         1 for j in range(num_samples)
-        if os.path.exists(os.path.join(RENDERS_DIR,  f"render_{j:04d}.png"))
-        and os.path.exists(os.path.join(DEPTH_DIR,   f"depth_{j:04d}.npy"))
-        and os.path.exists(os.path.join(NORMALS_DIR, f"normals_{j:04d}.npy"))
-        and os.path.exists(os.path.join(MASKS_DIR,   f"mask_{j:04d}.png"))
+        if os.path.exists(os.path.join(RENDERS_DIR,       f"render_{j:04d}.png"))
+        and os.path.exists(os.path.join(DEPTH_DIR,        f"depth_{j:04d}.npy"))
+        and os.path.exists(os.path.join(NORMALS_DIR,      f"normals_{j:04d}.npy"))
+        and os.path.exists(os.path.join(MASKS_DIR,        f"mask_{j:04d}.png"))
+        and os.path.exists(os.path.join(PBR_ALBEDO_DIR,   f"albedo_{j:04d}.png"))
+        and os.path.exists(os.path.join(PBR_ROUGHNESS_DIR, f"roughness_{j:04d}.png"))
+        and os.path.exists(os.path.join(PBR_NORMAL_DIR,   f"normal_{j:04d}.png"))
     )
     print(f"Checkpoint: {existing}/{num_samples} frames already done, resuming.\n")
     print(
@@ -158,17 +164,23 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
     )
 
     for i in range(num_samples):
-        frame_str    = f"{i:04d}"
-        render_path  = os.path.join(RENDERS_DIR,  f"render_{frame_str}.png")
-        depth_path   = os.path.join(DEPTH_DIR,    f"depth_{frame_str}.npy")
-        normals_path = os.path.join(NORMALS_DIR,  f"normals_{frame_str}.npy")
-        mask_path    = os.path.join(MASKS_DIR,    f"mask_{frame_str}.png")
+        frame_str          = f"{i:04d}"
+        render_path        = os.path.join(RENDERS_DIR,        f"render_{frame_str}.png")
+        depth_path         = os.path.join(DEPTH_DIR,          f"depth_{frame_str}.npy")
+        normals_path       = os.path.join(NORMALS_DIR,        f"normals_{frame_str}.npy")
+        mask_path          = os.path.join(MASKS_DIR,          f"mask_{frame_str}.png")
+        pbr_albedo_path    = os.path.join(PBR_ALBEDO_DIR,     f"albedo_{frame_str}.png")
+        pbr_roughness_path = os.path.join(PBR_ROUGHNESS_DIR,  f"roughness_{frame_str}.png")
+        pbr_normal_path    = os.path.join(PBR_NORMAL_DIR,     f"normal_{frame_str}.png")
 
         # --- CHECKPOINT: skip frames that are fully complete (and have metadata) ---
         if (os.path.exists(render_path)
                 and os.path.exists(depth_path)
                 and os.path.exists(normals_path)
-                and os.path.exists(mask_path)):
+                and os.path.exists(mask_path)
+                and os.path.exists(pbr_albedo_path)
+                and os.path.exists(pbr_roughness_path)
+                and os.path.exists(pbr_normal_path)):
             if frame_str in existing_metadata:
                 metadata_records.append(existing_metadata[frame_str])
                 print(f"  [{i+1:>4}/{num_samples}] Skipping {frame_str} (already exists)")
@@ -433,7 +445,9 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
 
             'integrator': {
                 'type': 'aov',
-                'aovs': 'depth:depth,normals:sh_normal',
+                # Append-only AOV order: depth(4), normals(5-7), albedo(8-10).
+                # Existing channel slicing below depends on these positions.
+                'aovs': 'depth:depth,normals:sh_normal,albedo:albedo',
                 'my_path': {
                     'type': 'path',
                     # Low depth avoids long specular chains (fireflies / “glitter”) while
@@ -577,6 +591,30 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
         np.save(normals_path, normals_np.astype(np.float32))
 
         # -----------------------------------------------------------------------
+        # PBR ground-truth maps (Hybrid A + C)
+        #   • albedo  → Mitsuba aov:albedo channels 8-10 (linear RGB), masked
+        #   • normal  → re-encode normals_np from [-1,1] → [0,255] RGB, masked
+        #   • roughness → uniform fill from BSDF scalar × mask (Design C, post-hoc)
+        # All three are masked so the background is black and the cloth pixels
+        # carry the GT values. They share the camera/resolution of `render_path`.
+        # -----------------------------------------------------------------------
+        if render_np.shape[2] >= 11:
+            albedo_np = np.clip(render_np[:, :, 8:11], 0.0, 1.0)
+        else:
+            print(f"  [WARNING] Albedo AOV not found for {frame_str}; saving zero albedo.")
+            albedo_np = np.zeros((*render_np.shape[:2], 3), dtype=np.float32)
+        albedo_masked = albedo_np * mesh_alpha[..., None]
+        albedo_uint8 = (albedo_masked * 255).astype(np.uint8)
+        cv2.imwrite(pbr_albedo_path, cv2.cvtColor(albedo_uint8, cv2.COLOR_RGB2BGR))
+
+        normal_encoded = ((normals_np + 1.0) * 0.5).clip(0.0, 1.0)
+        normal_uint8 = (normal_encoded * 255 * mesh_alpha[..., None]).astype(np.uint8)
+        cv2.imwrite(pbr_normal_path, cv2.cvtColor(normal_uint8, cv2.COLOR_RGB2BGR))
+
+        roughness_uint8 = np.clip(roughness * mesh_alpha * 255.0, 0, 255).astype(np.uint8)
+        cv2.imwrite(pbr_roughness_path, roughness_uint8)
+
+        # -----------------------------------------------------------------------
         # Record per-frame metadata
         #
         # The Neural Contours Geometry Branch computes Suggestive Contours and
@@ -625,6 +663,10 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
             "pattern_params":     pattern_params,
             "albedo_map":         f"textures/texture_{frame_str}.png",
             "albedo_tiling":      [tile_u, tile_v],
+            # ── PBR ground-truth maps (pixel-aligned with renders/sketches) ──
+            "pbr_albedo":         f"pbr/albedo/albedo_{frame_str}.png",
+            "pbr_roughness":      f"pbr/roughness/roughness_{frame_str}.png",
+            "pbr_normal":         f"pbr/normal/normal_{frame_str}.png",
         })
 
         light_types_str = ', '.join(lm['type'] for lm in lights_meta)
@@ -644,10 +686,13 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
             f.write(json.dumps(record) + '\n')
 
     print(f"\n✓ Done!  {num_samples} render sets saved.")
-    print(f"  • beauty PNGs  → {RENDERS_DIR}")
-    print(f"  • depth .npy   → {DEPTH_DIR}")
-    print(f"  • normal .npy  → {NORMALS_DIR}")
-    print(f"  • metadata     → {METADATA_PATH}")
+    print(f"  • beauty PNGs   → {RENDERS_DIR}")
+    print(f"  • depth .npy    → {DEPTH_DIR}")
+    print(f"  • normal .npy   → {NORMALS_DIR}")
+    print(f"  • PBR albedo    → {PBR_ALBEDO_DIR}")
+    print(f"  • PBR roughness → {PBR_ROUGHNESS_DIR}")
+    print(f"  • PBR normal    → {PBR_NORMAL_DIR}")
+    print(f"  • metadata      → {METADATA_PATH}")
     print("\nNext: run  python generate_sketches.py  to run Neural Contours inference.")
 
 

--- a/cloth_pipeline/dataset/render_loop.py
+++ b/cloth_pipeline/dataset/render_loop.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from cloth_pipeline.dataset.textures import generate_random_albedo_map
 from cloth_pipeline.paths import (
+    BASE_DIR,
     DATASET_DIR,
     DEPTH_DIR,
     FRONT_PREVIEW_DIR,
@@ -21,12 +22,12 @@ from cloth_pipeline.paths import (
     MESHES_DIR,
     METADATA_PATH,
     NORMALS_DIR,
-    PBR_ALBEDO_DIR,
-    PBR_NORMAL_DIR,
-    PBR_ROUGHNESS_DIR,
+    OUTPUTS_DIR,
     RENDERS_DIR,
     ensure_dataset_stage_dirs,
     ensure_front_preview_dir,
+    output_sample_dir,
+    sample_dir_components,
 )
 
 mi.set_variant("scalar_rgb")
@@ -143,13 +144,10 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
 
     existing = sum(
         1 for j in range(num_samples)
-        if os.path.exists(os.path.join(RENDERS_DIR,       f"render_{j:04d}.png"))
-        and os.path.exists(os.path.join(DEPTH_DIR,        f"depth_{j:04d}.npy"))
-        and os.path.exists(os.path.join(NORMALS_DIR,      f"normals_{j:04d}.npy"))
-        and os.path.exists(os.path.join(MASKS_DIR,        f"mask_{j:04d}.png"))
-        and os.path.exists(os.path.join(PBR_ALBEDO_DIR,   f"albedo_{j:04d}.png"))
-        and os.path.exists(os.path.join(PBR_ROUGHNESS_DIR, f"roughness_{j:04d}.png"))
-        and os.path.exists(os.path.join(PBR_NORMAL_DIR,   f"normal_{j:04d}.png"))
+        if os.path.exists(os.path.join(RENDERS_DIR,  f"render_{j:04d}.png"))
+        and os.path.exists(os.path.join(DEPTH_DIR,   f"depth_{j:04d}.npy"))
+        and os.path.exists(os.path.join(NORMALS_DIR, f"normals_{j:04d}.npy"))
+        and os.path.exists(os.path.join(MASKS_DIR,   f"mask_{j:04d}.png"))
     )
     print(f"Checkpoint: {existing}/{num_samples} frames already done, resuming.\n")
     print(
@@ -164,29 +162,29 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
     )
 
     for i in range(num_samples):
-        frame_str          = f"{i:04d}"
-        render_path        = os.path.join(RENDERS_DIR,        f"render_{frame_str}.png")
-        depth_path         = os.path.join(DEPTH_DIR,          f"depth_{frame_str}.npy")
-        normals_path       = os.path.join(NORMALS_DIR,        f"normals_{frame_str}.npy")
-        mask_path          = os.path.join(MASKS_DIR,          f"mask_{frame_str}.png")
-        pbr_albedo_path    = os.path.join(PBR_ALBEDO_DIR,     f"albedo_{frame_str}.png")
-        pbr_roughness_path = os.path.join(PBR_ROUGHNESS_DIR,  f"roughness_{frame_str}.png")
-        pbr_normal_path    = os.path.join(PBR_NORMAL_DIR,     f"normal_{frame_str}.png")
+        frame_str    = f"{i:04d}"
+        render_path  = os.path.join(RENDERS_DIR,  f"render_{frame_str}.png")
+        depth_path   = os.path.join(DEPTH_DIR,    f"depth_{frame_str}.npy")
+        normals_path = os.path.join(NORMALS_DIR,  f"normals_{frame_str}.npy")
+        mask_path    = os.path.join(MASKS_DIR,    f"mask_{frame_str}.png")
 
-        # --- CHECKPOINT: skip frames that are fully complete (and have metadata) ---
-        if (os.path.exists(render_path)
+        # --- CHECKPOINT: skip when intermediates + recorded PBR sample dir
+        # all exist. The mesh+material+pattern combination chosen for a frame
+        # is random, so we read the recorded paths straight from metadata. ---
+        if (frame_str in existing_metadata
+                and os.path.exists(render_path)
                 and os.path.exists(depth_path)
                 and os.path.exists(normals_path)
-                and os.path.exists(mask_path)
-                and os.path.exists(pbr_albedo_path)
-                and os.path.exists(pbr_roughness_path)
-                and os.path.exists(pbr_normal_path)):
-            if frame_str in existing_metadata:
-                metadata_records.append(existing_metadata[frame_str])
+                and os.path.exists(mask_path)):
+            rec = existing_metadata[frame_str]
+            rec_paths = [rec.get("pbr_albedo"), rec.get("pbr_normal"), rec.get("pbr_roughness")]
+            if all(rec_paths) and all(
+                os.path.exists(os.path.join(BASE_DIR, p)) for p in rec_paths
+            ):
+                metadata_records.append(rec)
                 print(f"  [{i+1:>4}/{num_samples}] Skipping {frame_str} (already exists)")
                 continue
-            # No metadata for this frame — must re-render to populate it
-            print(f"  [{i+1:>4}/{num_samples}] Re-rendering {frame_str} (missing metadata)")
+            print(f"  [{i+1:>4}/{num_samples}] Re-rendering {frame_str} (PBR outputs missing)")
 
         print(
             f"  [{i+1:>4}/{num_samples}] Frame {frame_str}: setup (mesh, lights, materials)…",
@@ -591,13 +589,27 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
         np.save(normals_path, normals_np.astype(np.float32))
 
         # -----------------------------------------------------------------------
-        # PBR ground-truth maps (Hybrid A + C)
-        #   • albedo  → Mitsuba aov:albedo channels 8-10 (linear RGB), masked
-        #   • normal  → re-encode normals_np from [-1,1] → [0,255] RGB, masked
-        #   • roughness → uniform fill from BSDF scalar × mask (Design C, post-hoc)
-        # All three are masked so the background is black and the cloth pixels
-        # carry the GT values. They share the camera/resolution of `render_path`.
+        # PBR ground-truth maps → outputs/mesh_<stem>/<material>_<pattern>/view_<idx>/sample_<frame>/
+        #   • albedo.png    → Mitsuba aov:albedo channels 8-10 (linear RGB), masked
+        #   • normal.png    → re-encode normals_np from [-1,1] → [0,255] RGB, masked
+        #   • roughness.png → uniform fill from BSDF scalar × mask (Design C, post-hoc)
+        # The per-sample frame folder makes every frame collision-free, so two
+        # frames picking the same (mesh, material, pattern, view) live side by
+        # side as different lighting variations.
         # -----------------------------------------------------------------------
+        view_idx = 0  # multi-view rendering not implemented yet
+        frame_id = i
+        sample_parts = sample_dir_components(
+            current_mesh_path, material_desc, pattern_name, view_idx, frame_id
+        )
+        sample_out_dir = output_sample_dir(
+            current_mesh_path, material_desc, pattern_name, view_idx, frame_id
+        )
+        os.makedirs(sample_out_dir, exist_ok=True)
+        pbr_albedo_path    = os.path.join(sample_out_dir, "albedo.png")
+        pbr_normal_path    = os.path.join(sample_out_dir, "normal.png")
+        pbr_roughness_path = os.path.join(sample_out_dir, "roughness.png")
+
         if render_np.shape[2] >= 11:
             albedo_np = np.clip(render_np[:, :, 8:11], 0.0, 1.0)
         else:
@@ -663,10 +675,19 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
             "pattern_params":     pattern_params,
             "albedo_map":         f"textures/texture_{frame_str}.png",
             "albedo_tiling":      [tile_u, tile_v],
-            # ── PBR ground-truth maps (pixel-aligned with renders/sketches) ──
-            "pbr_albedo":         f"pbr/albedo/albedo_{frame_str}.png",
-            "pbr_roughness":      f"pbr/roughness/roughness_{frame_str}.png",
-            "pbr_normal":         f"pbr/normal/normal_{frame_str}.png",
+            # ── Mesh / material+pattern / view / sample hierarchy ──
+            "frame_id":                  frame_id,
+            "mesh_dir_name":             sample_parts["mesh_dir_name"],
+            "material_pattern_dir_name": sample_parts["material_pattern_dir_name"],
+            "view_idx":                  view_idx,
+            "sample_dir_name":           sample_parts["sample_dir_name"],
+            "sample_output_dir":         os.path.relpath(sample_out_dir, BASE_DIR),
+            "pbr_albedo":                os.path.relpath(pbr_albedo_path,    BASE_DIR),
+            "pbr_roughness":             os.path.relpath(pbr_roughness_path, BASE_DIR),
+            "pbr_normal":                os.path.relpath(pbr_normal_path,    BASE_DIR),
+            "sketch_path":               os.path.relpath(
+                os.path.join(sample_out_dir, "sketch.png"), BASE_DIR
+            ),
         })
 
         light_types_str = ', '.join(lm['type'] for lm in lights_meta)
@@ -689,11 +710,9 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
     print(f"  • beauty PNGs   → {RENDERS_DIR}")
     print(f"  • depth .npy    → {DEPTH_DIR}")
     print(f"  • normal .npy   → {NORMALS_DIR}")
-    print(f"  • PBR albedo    → {PBR_ALBEDO_DIR}")
-    print(f"  • PBR roughness → {PBR_ROUGHNESS_DIR}")
-    print(f"  • PBR normal    → {PBR_NORMAL_DIR}")
+    print(f"  • PBR maps      → {OUTPUTS_DIR}/mesh_<stem>/<mat>_<pat>/view_0/sample_NNNN/")
     print(f"  • metadata      → {METADATA_PATH}")
-    print("\nNext: run  python generate_sketches.py  to run Neural Contours inference.")
+    print("\nNext: run  python generate_sketches.py  to write sketch.png next to PBR maps.")
 
 
 def run_front_mesh_previews(*, only_stem: str | None = None) -> None:

--- a/cloth_pipeline/paths.py
+++ b/cloth_pipeline/paths.py
@@ -1,6 +1,7 @@
 """Project-root paths used by Stage 1 (dataset) and Stage 2 (sketches)."""
 
 import os
+import re
 
 _PKG_DIR = os.path.dirname(os.path.abspath(__file__))
 BASE_DIR = os.path.dirname(_PKG_DIR)
@@ -14,30 +15,69 @@ MASKS_DIR = os.path.join(DATASET_DIR, "masks")
 # Procedural albedo / pattern maps (Mitsuba base_color). Folder name is historical.
 ALBEDO_MAPS_DIR = os.path.join(DATASET_DIR, "textures")
 TEXTURES_DIR = ALBEDO_MAPS_DIR  # deprecated alias — same path as ALBEDO_MAPS_DIR
-CONDITION_DIR = os.path.join(DATASET_DIR, "conditioning")
 METADATA_PATH = os.path.join(DATASET_DIR, "metadata.jsonl")
 FRONT_PREVIEW_DIR = os.path.join(DATASET_DIR, "front_previews")
 
-# PBR ground-truth maps, pixel-aligned with renders/sketches.
-# Albedo + normal come from the Mitsuba AOV pass; roughness is a post-hoc
-# uniform fill from material_props (single BSDF per garment for now).
-PBR_DIR = os.path.join(DATASET_DIR, "pbr")
-PBR_ALBEDO_DIR = os.path.join(PBR_DIR, "albedo")
-PBR_ROUGHNESS_DIR = os.path.join(PBR_DIR, "roughness")
-PBR_NORMAL_DIR = os.path.join(PBR_DIR, "normal")
+# Training-ready outputs (sketch + PBR maps), grouped per mesh / view.
+# Stage 1 writes albedo/normal/roughness here; Stage 2 writes sketch here.
+# Layout: outputs/mesh_<sanitized_stem>/view_<idx>/{sketch,albedo,normal,roughness}.png
+OUTPUTS_DIR = os.path.join(BASE_DIR, "outputs")
+
+
+def sanitize_mesh_name(stem: str) -> str:
+    """Lowercase + collapse non-alphanumeric runs to underscores; strip edges.
+    Generic enough to use for any path component (mesh, material, pattern)."""
+    s = stem.lower()
+    s = re.sub(r"[^a-z0-9]+", "_", s)
+    return s.strip("_")
+
+
+def sample_dir_components(
+    mesh_path: str,
+    material_type: str,
+    pattern_name: str,
+    view_idx: int,
+    frame_id: int,
+) -> dict:
+    """Named pieces of the per-sample output directory; mirror these into metadata."""
+    mesh_stem = os.path.splitext(os.path.basename(mesh_path))[0]
+    return {
+        "mesh_dir_name": f"mesh_{sanitize_mesh_name(mesh_stem)}",
+        "material_pattern_dir_name": (
+            f"{sanitize_mesh_name(material_type)}_{sanitize_mesh_name(pattern_name)}"
+        ),
+        "view_idx": int(view_idx),
+        "sample_dir_name": f"sample_{int(frame_id):04d}",
+    }
+
+
+def output_sample_dir(
+    mesh_path: str,
+    material_type: str,
+    pattern_name: str,
+    view_idx: int,
+    frame_id: int,
+) -> str:
+    """Absolute path to the per-(mesh, material+pattern, view, frame) directory."""
+    parts = sample_dir_components(mesh_path, material_type, pattern_name, view_idx, frame_id)
+    return os.path.join(
+        OUTPUTS_DIR,
+        parts["mesh_dir_name"],
+        parts["material_pattern_dir_name"],
+        f"view_{parts['view_idx']}",
+        parts["sample_dir_name"],
+    )
 
 
 def ensure_dataset_stage_dirs() -> None:
+    """Create flat intermediate dirs + the outputs/ root (per-mesh subdirs are
+    created on demand at write time)."""
     for d in (
-        RENDERS_DIR, DEPTH_DIR, NORMALS_DIR, MASKS_DIR, MESHES_DIR, ALBEDO_MAPS_DIR,
-        PBR_ALBEDO_DIR, PBR_ROUGHNESS_DIR, PBR_NORMAL_DIR,
+        RENDERS_DIR, DEPTH_DIR, NORMALS_DIR, MASKS_DIR, MESHES_DIR,
+        ALBEDO_MAPS_DIR, OUTPUTS_DIR,
     ):
         os.makedirs(d, exist_ok=True)
 
 
 def ensure_front_preview_dir() -> None:
     os.makedirs(FRONT_PREVIEW_DIR, exist_ok=True)
-
-
-def ensure_sketch_stage_dirs() -> None:
-    os.makedirs(CONDITION_DIR, exist_ok=True)

--- a/cloth_pipeline/paths.py
+++ b/cloth_pipeline/paths.py
@@ -18,9 +18,20 @@ CONDITION_DIR = os.path.join(DATASET_DIR, "conditioning")
 METADATA_PATH = os.path.join(DATASET_DIR, "metadata.jsonl")
 FRONT_PREVIEW_DIR = os.path.join(DATASET_DIR, "front_previews")
 
+# PBR ground-truth maps, pixel-aligned with renders/sketches.
+# Albedo + normal come from the Mitsuba AOV pass; roughness is a post-hoc
+# uniform fill from material_props (single BSDF per garment for now).
+PBR_DIR = os.path.join(DATASET_DIR, "pbr")
+PBR_ALBEDO_DIR = os.path.join(PBR_DIR, "albedo")
+PBR_ROUGHNESS_DIR = os.path.join(PBR_DIR, "roughness")
+PBR_NORMAL_DIR = os.path.join(PBR_DIR, "normal")
+
 
 def ensure_dataset_stage_dirs() -> None:
-    for d in (RENDERS_DIR, DEPTH_DIR, NORMALS_DIR, MASKS_DIR, MESHES_DIR, ALBEDO_MAPS_DIR):
+    for d in (
+        RENDERS_DIR, DEPTH_DIR, NORMALS_DIR, MASKS_DIR, MESHES_DIR, ALBEDO_MAPS_DIR,
+        PBR_ALBEDO_DIR, PBR_ROUGHNESS_DIR, PBR_NORMAL_DIR,
+    ):
         os.makedirs(d, exist_ok=True)
 
 

--- a/cloth_pipeline/sketch/pipeline.py
+++ b/cloth_pipeline/sketch/pipeline.py
@@ -1,4 +1,9 @@
-"""Render → conditioning sketch (edges, silhouette, hatching, labels)."""
+"""Render → conditioning sketch (edges, silhouette, hatching, glyphs).
+
+Returns a raw render-sized BGR canvas so the sketch is pixel-aligned with the
+beauty render and PBR maps. The decorated text-band variant has been retired
+along with the legacy ``dataset/conditioning/`` output.
+"""
 
 from __future__ import annotations
 
@@ -6,84 +11,23 @@ import os
 
 import cv2
 import numpy as np
-from PIL import Image, ImageDraw
 
 from cloth_pipeline.paths import DATASET_DIR
-from cloth_pipeline.sketch.constants import SKETCH_BGR, SKETCH_RGB, USE_TEXTURE_STROKES
+from cloth_pipeline.sketch.constants import SKETCH_BGR, USE_TEXTURE_STROKES
 from cloth_pipeline.sketch.drawing import (
     albedo_pattern_stroke_mask,
-    draw_annotations,
     draw_depth_layer_boundary,
     draw_occlusion_edges,
     draw_shade_marks,
     draw_wobbly_contour,
-    measure_top_left_text_pad,
 )
 from cloth_pipeline.sketch.edges import detect_edges
-from cloth_pipeline.sketch.features import detect_dominant_color, find_feature_points
+from cloth_pipeline.sketch.features import find_feature_points
 from cloth_pipeline.sketch.segmentation import get_object_mask
 
 
-def _nonwhite_bbox(img_bgr: np.ndarray, threshold: int = 250) -> tuple[int, int, int, int] | None:
-    gray = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2GRAY)
-    ys, xs = np.where(gray < threshold)
-    if ys.size == 0:
-        return None
-    return int(xs.min()), int(ys.min()), int(xs.max()), int(ys.max())
-
-
-def _place_scaled_content(
-    content_bgr: np.ndarray,
-    out_w: int,
-    out_h: int,
-    *,
-    pad_left: int,
-    pad_top: int,
-    pad_right: int,
-    pad_bottom: int,
-) -> np.ndarray:
-    """
-    Crop to the inked sketch region, scale it up moderately, and place it in
-    the drawable area that remains after reserving the top-left text block.
-    """
-    full = np.full((out_h, out_w, 3), 255, dtype=np.uint8)
-    bbox = _nonwhite_bbox(content_bgr)
-    if bbox is None:
-        full[pad_top : pad_top + content_bgr.shape[0], pad_left : pad_left + content_bgr.shape[1]] = content_bgr
-        return full
-
-    x0, y0, x1, y1 = bbox
-    crop = content_bgr[y0 : y1 + 1, x0 : x1 + 1]
-    ch, cw = crop.shape[:2]
-
-    avail_x0 = max(18, pad_left + 12)
-    avail_y0 = max(18, pad_top + 10)
-    avail_x1 = max(avail_x0 + 1, out_w - pad_right + max(18, pad_right // 3))
-    avail_y1 = max(avail_y0 + 1, out_h - pad_bottom + max(18, pad_bottom // 3))
-    avail_w = max(1, avail_x1 - avail_x0)
-    avail_h = max(1, avail_y1 - avail_y0)
-
-    scale = min(avail_w / float(max(1, cw)), avail_h / float(max(1, ch)), 1.45)
-    if scale <= 0:
-        scale = 1.0
-    new_w = max(1, int(round(cw * scale)))
-    new_h = max(1, int(round(ch * scale)))
-    interp = cv2.INTER_CUBIC if scale > 1.0 else cv2.INTER_AREA
-    placed = cv2.resize(crop, (new_w, new_h), interpolation=interp)
-
-    off_x = avail_x0 + max(0, (avail_w - new_w) // 2)
-    off_y = avail_y0 + max(0, (avail_h - new_h) // 2)
-    region = full[off_y : off_y + new_h, off_x : off_x + new_w]
-    gray = cv2.cvtColor(placed, cv2.COLOR_BGR2GRAY)
-    ink = gray < 250
-    region[ink] = placed[ink]
-    return full
-
 def generate_sketch(
     render_path:    str,
-    obj_name:       str,
-    material_label: str,
-    texture_label:  str,
     *,
     alpha_mask_path: str | None = None,
     albedo_map_path: str | None = None,
@@ -91,19 +35,11 @@ def generate_sketch(
     pattern_name:    str | None = None,
 ) -> np.ndarray:
     """
-    Full render → conditioning sketch pipeline.
+    Render → render-sized BGR sketch canvas (no text band, no rescaling).
 
-    When ``albedo_map_path`` / ``albedo_tiling`` / ``pattern_name`` are set (from
-    dataset metadata), the same procedural albedo PNG used for Mitsuba ``base_color``
-    is tiled and converted to sparse in-mask strokes so pattern is separate from
-    lighting-dependent structure in the RGB render.
-
-    Fabric preset is written in the top-left text block (``material_label``), not
-    as strokes on the cloth. The output canvas adds equal padding on opposite sides
-    (right = left, bottom = top) so the ``w×h`` sketch stays **centred** like the
-    source render, while the top-left quadrant stays clear for captions.
-
-    Returns a BGR uint8 image ready for cv2.imwrite.
+    The returned canvas matches ``render_path``'s width/height exactly, so the
+    sketch is pixel-aligned with the beauty render and the PBR maps written by
+    Stage 1 to ``outputs/<mesh>/view_<idx>/``.
     """
     # Load as BGRA so we can extract the alpha channel saved by generate_dataset.
     # cv2.IMREAD_UNCHANGED preserves all 4 channels when they exist.
@@ -203,50 +139,5 @@ def generate_sketch(
 
     features_pts = find_feature_points(img_bgr, seg_mask)
     draw_shade_marks(canvas, features_pts, SKETCH_BGR)
-
-    # ── Colour detection for text ─────────────────────────────────────────────
-    dominant_color = detect_dominant_color(img_bgr, seg_mask)
-
-    # ── D: Annotation + reserved top-left band ───────────────────────────────
-    mat_display = (
-        material_label.replace(" texture", "").replace(" Texture", "")
-        .replace("Coarse ", "").replace("coarse ", "")
-        .strip()
-    )
-    short_name = obj_name.replace("Wool ", "").replace("wool ", "")
-    text_lines = [
-        f"Material: {mat_display}",
-        f"Object: {short_name} ({dominant_color})",
-        f"Texture: {texture_label}",
-    ]
-    pad_left, pad_top = measure_top_left_text_pad(text_lines)
-    # Keep a generous text band at top-left, but trim the opposite margins so
-    # the scarf takes up more of the page than in earlier versions.
-    pad_right = max(44, int(round(pad_left * 0.42)))
-    pad_bottom = max(40, int(round(pad_top * 0.35)))
-    out_w = pad_left + w + pad_right
-    out_h = pad_top + h + pad_bottom
-    full = _place_scaled_content(
-        canvas,
-        out_w,
-        out_h,
-        pad_left=pad_left,
-        pad_top=pad_top,
-        pad_right=pad_right,
-        pad_bottom=pad_bottom,
-    )
-
-    pil = Image.fromarray(cv2.cvtColor(full, cv2.COLOR_BGR2RGB))
-    draw = ImageDraw.Draw(pil)
-
-    draw_annotations(
-        draw,
-        text_lines,
-        {},
-        canvas_wh=(out_w, out_h),
-        color=SKETCH_RGB,
-        sketch_content_top=pad_top,
-    )
-    canvas = cv2.cvtColor(np.array(pil), cv2.COLOR_RGB2BGR)
 
     return canvas

--- a/cloth_pipeline/sketch/runner.py
+++ b/cloth_pipeline/sketch/runner.py
@@ -1,4 +1,4 @@
-"""Batch over metadata.jsonl → conditioning images."""
+"""Batch over metadata.jsonl → outputs/<mesh>/view_<idx>/sketch.png."""
 
 from __future__ import annotations
 
@@ -7,25 +7,8 @@ import os
 
 import cv2
 
-from cloth_pipeline.paths import CONDITION_DIR, DATASET_DIR, METADATA_PATH, ensure_sketch_stage_dirs
+from cloth_pipeline.paths import BASE_DIR, DATASET_DIR, METADATA_PATH
 from cloth_pipeline.sketch.pipeline import generate_sketch
-
-
-def _material_label_from_meta(meta: dict) -> str:
-    """Human-readable fabric preset (BRDF category), not albedo pattern."""
-    mt = meta.get("material_type")
-    if mt:
-        s = str(mt).replace("_", " ").strip()
-        return s[0].upper() + s[1:] if s else "Fabric"
-    legacy = meta.get("texture_type")
-    if legacy:
-        return (
-            str(legacy)
-            .replace(" texture", "")
-            .replace(" Texture", "")
-            .strip()
-        )
-    return "Wool"
 
 
 def _albedo_rel_from_meta(meta: dict) -> str | None:
@@ -44,46 +27,31 @@ def _pattern_name_from_meta(meta: dict) -> str | None:
     return meta.get("pattern_name") or meta.get("texture_pattern")
 
 
-def _texture_label_from_meta(meta: dict) -> str:
-    """Caption for the third annotation line (pattern-first, e.g. Stripes)."""
-    raw = _pattern_name_from_meta(meta)
-    if raw is not None and str(raw).strip():
-        s = str(raw).replace("_", " ").strip()
-        return s.title() if s else "Plain"
-    kw = meta.get("keyword")
-    if kw is not None and str(kw).strip():
-        return str(kw).strip()
-    return "Plain"
-
-
-def run_from_metadata(*, output_dir: str | None = None) -> None:
-    ensure_sketch_stage_dirs()
-    condition_dir = output_dir or CONDITION_DIR
-    os.makedirs(condition_dir, exist_ok=True)
-
-    if os.path.exists(METADATA_PATH):
-        with open(METADATA_PATH) as f:
-            records = [json.loads(ln) for ln in f if ln.strip()]
-    else:
-        records = []
+def run_from_metadata() -> None:
+    if not os.path.exists(METADATA_PATH):
         print(f"[WARNING] metadata.jsonl not found at {METADATA_PATH}.")
         print("  Run generate_dataset.py first, then re-run this script.")
+        return
+
+    with open(METADATA_PATH) as f:
+        records = [json.loads(ln) for ln in f if ln.strip()]
 
     for meta in records:
         frame_str   = meta["frame"]
         render_path = os.path.join(
             DATASET_DIR, meta.get("file_name", f"renders/render_{frame_str}.png")
         )
-        out_path = os.path.join(condition_dir, f"conditioning_{frame_str}.png")
+
+        sketch_rel = meta.get("sketch_path")
+        if not sketch_rel:
+            print(f"  [{frame_str}] [SKIP] sketch_path missing — re-run generate_dataset.py.")
+            continue
+        out_path = os.path.join(BASE_DIR, sketch_rel)
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
 
         if os.path.exists(out_path):
             print(f"  [{frame_str}] Skipping (already exists)")
             continue
-
-        raw_text = meta.get("text", "")
-        texture_label = _texture_label_from_meta(meta)
-        material_label = _material_label_from_meta(meta)
-        obj_name = "Wool Scarf" if "wool" in raw_text.lower() else "Cloth"
 
         tex_rel = _albedo_rel_from_meta(meta)
         albedo_map_path = (
@@ -97,9 +65,6 @@ def run_from_metadata(*, output_dir: str | None = None) -> None:
         try:
             sketch = generate_sketch(
                 render_path,
-                obj_name,
-                material_label,
-                texture_label,
                 alpha_mask_path=alpha_mask_path,
                 albedo_map_path=albedo_map_path,
                 albedo_tiling=_albedo_tiling_from_meta(meta),

--- a/generate_sketches.py
+++ b/generate_sketches.py
@@ -1,7 +1,8 @@
 """
 generate_sketches.py
 --------------------
-Stage 2: Mitsuba renders → aligned sketch conditioning images.
+Stage 2: Mitsuba renders → aligned sketch images written to
+``outputs/<mesh>/view_<idx>/sketch.png`` next to the PBR maps from Stage 1.
 
 The CV pipeline is split under ``cloth_pipeline.sketch`` (edges, segmentation,
 shadows, features, drawing, batch runner). Run from project root:
@@ -11,16 +12,7 @@ shadows, features, drawing, batch runner). Run from project root:
 See module docstrings there for HED/SAM optional models and env vars.
 """
 
-import argparse
-
 from cloth_pipeline.sketch import run_from_metadata
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Generate conditioning sketches from renders.")
-    parser.add_argument(
-        "--output-dir",
-        default=None,
-        help="Output directory for conditioning images (default: dataset/conditioning).",
-    )
-    args = parser.parse_args()
-    run_from_metadata(output_dir=args.output_dir)
+    run_from_metadata()


### PR DESCRIPTION
## Summary
Reorganises Stage 1 + Stage 2 to write training-ready PNGs into a per-sample directory keyed by `(mesh, material+pattern, view_idx, frame_id)`:

```
outputs/
└── mesh_<stem>/
    └── <material>_<pattern>/
        └── view_<idx>/
            └── sample_<frame_id>/
                ├── albedo.png
                ├── normal.png
                ├── roughness.png
                └── sketch.png
```

The frame-id-keyed sample folder makes every frame collision-free, so two frames sharing the same `(mesh, material, pattern, view)` but different lighting end up as sibling `sample_NNNN/` folders — exactly the disentanglement scenario we want for training material vs. lighting.

This builds on top of #11. Includes both commits: PBR maps + this hierarchy refactor.

## Changes
- `paths.py` — replace `output_view_dir` / `mesh_view_dir_name` with `output_sample_dir` and `sample_dir_components`. Generic `sanitize_mesh_name` is reused for material/pattern path components.
- `render_loop.py` — Stage 1 writes `albedo/normal/roughness.png` directly into the per-sample folder; metadata records `frame_id`, `mesh_dir_name`, `material_pattern_dir_name`, `view_idx`, `sample_dir_name`, full paths to all four PNGs. Checkpoint reads the recorded paths back from metadata.
- `sketch/pipeline.py` — `generate_sketch` returns the raw render-sized BGR canvas (text-band code retired). Signature simplified.
- `sketch/runner.py` — Stage 2 reads `sketch_path` from metadata and writes `sketch.png` next to the PBR maps. Per-sample checkpoint, no cross-frame skipping.
- `generate_sketches.py` — drop the no-longer-meaningful `--output-dir` CLI flag.

## Test plan
- [x] `rm -rf dataset/ outputs/`
- [x] `python3 generate_dataset.py` — 3 frames, 3 sample dirs, all 3 PBR PNGs each
- [x] `python3 generate_sketches.py` — 3 sketch.png written into the matching sample dirs
- [x] All 12 PNGs (3 samples × 4 maps) at 512×512, pixel-aligned with renders
- [x] Each sample dir's 4 PNGs all come from the same frame (no cross-frame mix)
- [x] Re-running both stages skips on per-sample checkpoint
- [ ] Visual review by @AcarBasaran before merging

## Out of scope
- Multi-view rendering (`view_0` is hardcoded; the hierarchy already accommodates `view_1`, `view_2`, … when added)
- Spatially-varying PBR / per-region material tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)