### PR TITLE
Deterministic mesh iteration: N variations per mesh

### DIFF
--- a/cloth_pipeline/dataset/render_loop.py
+++ b/cloth_pipeline/dataset/render_loop.py
@@ -114,7 +114,11 @@ def _suppress_mc_sparkles(rgb: np.ndarray) -> np.ndarray:
     return np.clip(rgb * scale[..., None], 0.0, 1.0)
 
 
-def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
+def run_generation(variations_per_mesh: int = 3) -> None:
+    """For each mesh in cloth_meshes/, render ``variations_per_mesh`` samples
+    with random material/pattern/lighting. Mesh and camera are fixed; everything
+    else is randomised per variation. Total samples = N_meshes × variations_per_mesh.
+    """
     ensure_dataset_stage_dirs()
 
     mesh_files = sorted(glob.glob(os.path.join(MESHES_DIR, "*.obj")))
@@ -130,6 +134,12 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
         print(f"[ERROR] No .obj files found in {MESHES_DIR}.")
         print("Please add your cloth meshes to that folder and run again.")
         raise SystemExit(1)
+
+    num_samples = len(mesh_files) * variations_per_mesh
+    print(
+        f"Generating {len(mesh_files)} meshes × {variations_per_mesh} variations "
+        f"= {num_samples} samples\n"
+    )
 
     # Load existing metadata so we preserve it when skipping frames
     existing_metadata = {}
@@ -192,8 +202,12 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
         )
 
         # -----------------------------------------------------------------------
-        # Randomise Geometry (optional: pin mesh when regenerating one frame)
+        # Mesh: deterministic outer iteration (sorted), inner = variation index.
+        # Optional env override pins one frame to a specific mesh stem.
         # -----------------------------------------------------------------------
+        mesh_idx = i // variations_per_mesh
+        variation_idx = i % variations_per_mesh
+
         only_frame_env = os.environ.get("NECH_ONLY_FRAME", "").strip()
         force_stem = os.environ.get("NECH_FORCE_MESH_STEM", "").strip()
         pin_idx: int | None = None
@@ -210,7 +224,7 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
                 )
             current_mesh_path = forced_path
         else:
-            current_mesh_path = random.choice(mesh_files)
+            current_mesh_path = mesh_files[mesh_idx]
         mesh_name = os.path.basename(current_mesh_path).replace(".obj", "")
 
         # Calculate bounding box for this specific mesh to frame it correctly
@@ -677,6 +691,8 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
             "albedo_tiling":      [tile_u, tile_v],
             # ── Mesh / material+pattern / view / sample hierarchy ──
             "frame_id":                  frame_id,
+            "mesh_idx":                  mesh_idx,
+            "variation_idx":             variation_idx,
             "mesh_dir_name":             sample_parts["mesh_dir_name"],
             "material_pattern_dir_name": sample_parts["material_pattern_dir_name"],
             "view_idx":                  view_idx,

--- a/cloth_pipeline/dataset/render_loop.py
+++ b/cloth_pipeline/dataset/render_loop.py
@@ -21,6 +21,9 @@ from cloth_pipeline.paths import (
     MESHES_DIR,
     METADATA_PATH,
     NORMALS_DIR,
+    PBR_ALBEDO_DIR,
+    PBR_NORMAL_DIR,
+    PBR_ROUGHNESS_DIR,
     RENDERS_DIR,
     ensure_dataset_stage_dirs,
     ensure_front_preview_dir,
@@ -140,10 +143,13 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
 
     existing = sum(
         1 for j in range(num_samples)
-        if os.path.exists(os.path.join(RENDERS_DIR,  f"render_{j:04d}.png"))
-        and os.path.exists(os.path.join(DEPTH_DIR,   f"depth_{j:04d}.npy"))
-        and os.path.exists(os.path.join(NORMALS_DIR, f"normals_{j:04d}.npy"))
-        and os.path.exists(os.path.join(MASKS_DIR,   f"mask_{j:04d}.png"))
+        if os.path.exists(os.path.join(RENDERS_DIR,       f"render_{j:04d}.png"))
+        and os.path.exists(os.path.join(DEPTH_DIR,        f"depth_{j:04d}.npy"))
+        and os.path.exists(os.path.join(NORMALS_DIR,      f"normals_{j:04d}.npy"))
+        and os.path.exists(os.path.join(MASKS_DIR,        f"mask_{j:04d}.png"))
+        and os.path.exists(os.path.join(PBR_ALBEDO_DIR,   f"albedo_{j:04d}.png"))
+        and os.path.exists(os.path.join(PBR_ROUGHNESS_DIR, f"roughness_{j:04d}.png"))
+        and os.path.exists(os.path.join(PBR_NORMAL_DIR,   f"normal_{j:04d}.png"))
     )
     print(f"Checkpoint: {existing}/{num_samples} frames already done, resuming.\n")
     print(
@@ -158,17 +164,23 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
     )
 
     for i in range(num_samples):
-        frame_str    = f"{i:04d}"
-        render_path  = os.path.join(RENDERS_DIR,  f"render_{frame_str}.png")
-        depth_path   = os.path.join(DEPTH_DIR,    f"depth_{frame_str}.npy")
-        normals_path = os.path.join(NORMALS_DIR,  f"normals_{frame_str}.npy")
-        mask_path    = os.path.join(MASKS_DIR,    f"mask_{frame_str}.png")
+        frame_str          = f"{i:04d}"
+        render_path        = os.path.join(RENDERS_DIR,        f"render_{frame_str}.png")
+        depth_path         = os.path.join(DEPTH_DIR,          f"depth_{frame_str}.npy")
+        normals_path       = os.path.join(NORMALS_DIR,        f"normals_{frame_str}.npy")
+        mask_path          = os.path.join(MASKS_DIR,          f"mask_{frame_str}.png")
+        pbr_albedo_path    = os.path.join(PBR_ALBEDO_DIR,     f"albedo_{frame_str}.png")
+        pbr_roughness_path = os.path.join(PBR_ROUGHNESS_DIR,  f"roughness_{frame_str}.png")
+        pbr_normal_path    = os.path.join(PBR_NORMAL_DIR,     f"normal_{frame_str}.png")
 
         # --- CHECKPOINT: skip frames that are fully complete (and have metadata) ---
         if (os.path.exists(render_path)
                 and os.path.exists(depth_path)
                 and os.path.exists(normals_path)
-                and os.path.exists(mask_path)):
+                and os.path.exists(mask_path)
+                and os.path.exists(pbr_albedo_path)
+                and os.path.exists(pbr_roughness_path)
+                and os.path.exists(pbr_normal_path)):
             if frame_str in existing_metadata:
                 metadata_records.append(existing_metadata[frame_str])
                 print(f"  [{i+1:>4}/{num_samples}] Skipping {frame_str} (already exists)")
@@ -433,7 +445,9 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
 
             'integrator': {
                 'type': 'aov',
-                'aovs': 'depth:depth,normals:sh_normal',
+                # Append-only AOV order: depth(4), normals(5-7), albedo(8-10).
+                # Existing channel slicing below depends on these positions.
+                'aovs': 'depth:depth,normals:sh_normal,albedo:albedo',
                 'my_path': {
                     'type': 'path',
                     # Low depth avoids long specular chains (fireflies / “glitter”) while
@@ -577,6 +591,30 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
         np.save(normals_path, normals_np.astype(np.float32))
 
         # -----------------------------------------------------------------------
+        # PBR ground-truth maps (Hybrid A + C)
+        #   • albedo  → Mitsuba aov:albedo channels 8-10 (linear RGB), masked
+        #   • normal  → re-encode normals_np from [-1,1] → [0,255] RGB, masked
+        #   • roughness → uniform fill from BSDF scalar × mask (Design C, post-hoc)
+        # All three are masked so the background is black and the cloth pixels
+        # carry the GT values. They share the camera/resolution of `render_path`.
+        # -----------------------------------------------------------------------
+        if render_np.shape[2] >= 11:
+            albedo_np = np.clip(render_np[:, :, 8:11], 0.0, 1.0)
+        else:
+            print(f"  [WARNING] Albedo AOV not found for {frame_str}; saving zero albedo.")
+            albedo_np = np.zeros((*render_np.shape[:2], 3), dtype=np.float32)
+        albedo_masked = albedo_np * mesh_alpha[..., None]
+        albedo_uint8 = (albedo_masked * 255).astype(np.uint8)
+        cv2.imwrite(pbr_albedo_path, cv2.cvtColor(albedo_uint8, cv2.COLOR_RGB2BGR))
+
+        normal_encoded = ((normals_np + 1.0) * 0.5).clip(0.0, 1.0)
+        normal_uint8 = (normal_encoded * 255 * mesh_alpha[..., None]).astype(np.uint8)
+        cv2.imwrite(pbr_normal_path, cv2.cvtColor(normal_uint8, cv2.COLOR_RGB2BGR))
+
+        roughness_uint8 = np.clip(roughness * mesh_alpha * 255.0, 0, 255).astype(np.uint8)
+        cv2.imwrite(pbr_roughness_path, roughness_uint8)
+
+        # -----------------------------------------------------------------------
         # Record per-frame metadata
         #
         # The Neural Contours Geometry Branch computes Suggestive Contours and
@@ -625,6 +663,10 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
             "pattern_params":     pattern_params,
             "albedo_map":         f"textures/texture_{frame_str}.png",
             "albedo_tiling":      [tile_u, tile_v],
+            # ── PBR ground-truth maps (pixel-aligned with renders/sketches) ──
+            "pbr_albedo":         f"pbr/albedo/albedo_{frame_str}.png",
+            "pbr_roughness":      f"pbr/roughness/roughness_{frame_str}.png",
+            "pbr_normal":         f"pbr/normal/normal_{frame_str}.png",
         })
 
         light_types_str = ', '.join(lm['type'] for lm in lights_meta)
@@ -644,10 +686,13 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
             f.write(json.dumps(record) + '\n')
 
     print(f"\n✓ Done!  {num_samples} render sets saved.")
-    print(f"  • beauty PNGs  → {RENDERS_DIR}")
-    print(f"  • depth .npy   → {DEPTH_DIR}")
-    print(f"  • normal .npy  → {NORMALS_DIR}")
-    print(f"  • metadata     → {METADATA_PATH}")
+    print(f"  • beauty PNGs   → {RENDERS_DIR}")
+    print(f"  • depth .npy    → {DEPTH_DIR}")
+    print(f"  • normal .npy   → {NORMALS_DIR}")
+    print(f"  • PBR albedo    → {PBR_ALBEDO_DIR}")
+    print(f"  • PBR roughness → {PBR_ROUGHNESS_DIR}")
+    print(f"  • PBR normal    → {PBR_NORMAL_DIR}")
+    print(f"  • metadata      → {METADATA_PATH}")
     print("\nNext: run  python generate_sketches.py  to run Neural Contours inference.")
 
 

--- a/cloth_pipeline/dataset/render_loop.py
+++ b/cloth_pipeline/dataset/render_loop.py
@@ -114,10 +114,20 @@ def _suppress_mc_sparkles(rgb: np.ndarray) -> np.ndarray:
     return np.clip(rgb * scale[..., None], 0.0, 1.0)
 
 
-def run_generation(variations_per_mesh: int = 3) -> None:
-    """For each mesh in cloth_meshes/, render ``variations_per_mesh`` samples
-    with random material/pattern/lighting. Mesh and camera are fixed; everything
-    else is randomised per variation. Total samples = N_meshes × variations_per_mesh.
+def run_generation(
+    materials_per_mesh: int = 3,
+    lightings_per_material: int = 2,
+) -> None:
+    """Three-level deterministic loop: mesh × (material+pattern) × lighting.
+
+    For each mesh, ``materials_per_mesh`` (material, pattern) combinations are
+    sampled. For each, ``lightings_per_material`` lighting setups are rendered.
+    Mesh, material and pattern are *fixed* across the lighting siblings, so
+    their albedo/normal/roughness GTs are identical and only the sketches
+    (which encode highlight/shadow positions) differ — the disentanglement
+    signal we want for training.
+
+    Total samples = N_meshes × materials_per_mesh × lightings_per_material.
     """
     ensure_dataset_stage_dirs()
 
@@ -135,11 +145,17 @@ def run_generation(variations_per_mesh: int = 3) -> None:
         print("Please add your cloth meshes to that folder and run again.")
         raise SystemExit(1)
 
-    num_samples = len(mesh_files) * variations_per_mesh
+    samples_per_mesh = materials_per_mesh * lightings_per_material
+    num_samples = len(mesh_files) * samples_per_mesh
     print(
-        f"Generating {len(mesh_files)} meshes × {variations_per_mesh} variations "
-        f"= {num_samples} samples\n"
+        f"Generating {len(mesh_files)} meshes × {materials_per_mesh} materials "
+        f"× {lightings_per_material} lightings = {num_samples} samples\n"
     )
+
+    # (mesh_idx, material_idx) → cached material + pattern + texture, so all
+    # `lightings_per_material` siblings of the same (mesh, material) combo
+    # share bit-identical PBR inputs. Reset per run; in-memory only.
+    material_pattern_cache: dict[tuple[int, int], dict] = {}
 
     # Load existing metadata so we preserve it when skipping frames
     existing_metadata = {}
@@ -149,6 +165,38 @@ def run_generation(variations_per_mesh: int = 3) -> None:
                 if ln.strip():
                     rec = json.loads(ln)
                     existing_metadata[rec["frame"]] = rec
+
+    # Pre-populate the material+pattern cache from existing metadata so that a
+    # mid-run restart (e.g. after a Mitsuba segfault) reuses the SAME material
+    # and texture for the second lighting sibling instead of re-rolling. Without
+    # this, the (mesh, material+pattern) → lighting-pair invariant is violated.
+    for rec in existing_metadata.values():
+        if "mesh_idx" not in rec or "material_idx" not in rec:
+            continue
+        cache_key = (int(rec["mesh_idx"]), int(rec["material_idx"]))
+        if cache_key in material_pattern_cache:
+            continue
+        tex_rel = rec.get("albedo_map")
+        tex_path = os.path.join(DATASET_DIR, tex_rel) if tex_rel else None
+        if not tex_path or not os.path.exists(tex_path):
+            continue
+        props = rec.get("material_props") or {}
+        tiling = rec.get("albedo_tiling") or [1.0, 1.0]
+        material_pattern_cache[cache_key] = {
+            "material_desc":   rec.get("material_type"),
+            "roughness":       float(props.get("roughness", 0.5)),
+            "specular":        float(props.get("specular", 0.5)),
+            "sheen":           float(props.get("sheen", 0.5)),
+            "sheen_tint":      float(props.get("sheen_tint", 0.5)),
+            "anisotropic":     float(props.get("anisotropic", 0.0)),
+            "spec_trans":      float(props.get("spec_trans", 0.0)),
+            "clearcoat":       float(props.get("clearcoat", 0.0)),
+            "tex_path":        tex_path,
+            "pattern_name":    rec.get("pattern_name", "solid"),
+            "pattern_params":  rec.get("pattern_params", {}),
+            "tile_u":          float(tiling[0]),
+            "tile_v":          float(tiling[1]),
+        }
 
     metadata_records = []
 
@@ -202,11 +250,13 @@ def run_generation(variations_per_mesh: int = 3) -> None:
         )
 
         # -----------------------------------------------------------------------
-        # Mesh: deterministic outer iteration (sorted), inner = variation index.
+        # Three-level index: outer mesh / middle material / inner lighting.
         # Optional env override pins one frame to a specific mesh stem.
         # -----------------------------------------------------------------------
-        mesh_idx = i // variations_per_mesh
-        variation_idx = i % variations_per_mesh
+        mesh_idx = i // samples_per_mesh
+        within_mesh = i % samples_per_mesh
+        material_idx = within_mesh // lightings_per_material
+        lighting_idx = within_mesh % lightings_per_material
 
         only_frame_env = os.environ.get("NECH_ONLY_FRAME", "").strip()
         force_stem = os.environ.get("NECH_FORCE_MESH_STEM", "").strip()
@@ -389,45 +439,75 @@ def run_generation(variations_per_mesh: int = 3) -> None:
             },
         }
 
-        material_desc = random.choice(list(FABRIC_PRESETS.keys()))
-        preset = FABRIC_PRESETS[material_desc]
+        # Material + pattern is cached per (mesh_idx, material_idx) so all
+        # lighting siblings within a (mesh, material) group reuse the same
+        # BRDF parameters AND the same procedural texture file → byte-identical
+        # albedo/normal/roughness PBR ground truth.
+        cache_key = (mesh_idx, material_idx)
+        if cache_key not in material_pattern_cache:
+            material_desc = random.choice(list(FABRIC_PRESETS.keys()))
+            preset = FABRIC_PRESETS[material_desc]
 
-        def _sample(key):
-            lo, hi = preset[key]
-            return random.uniform(lo, hi)
+            def _sample(key, _p=preset):
+                lo, hi = _p[key]
+                return random.uniform(lo, hi)
 
-        roughness   = _sample('roughness')
-        specular    = _sample('specular')
-        sheen       = _sample('sheen')
-        sheen_tint  = _sample('sheen_tint')
-        anisotropic = _sample('anisotropic')
-        spec_trans  = _sample('spec_trans')
-        clearcoat   = _sample('clearcoat')
+            tex_path, pattern_name, pattern_params = generate_random_albedo_map(frame_str)
 
-        keyword = f"{material_desc} pattern"
+            # Analyse mesh UV range to choose a tiling factor that makes the pattern
+            # repeat at a visually sensible scale regardless of how the OBJ was UV-unwrapped.
+            uv_u_range, uv_v_range = 1.0, 1.0
+            try:
+                with open(current_mesh_path) as _mf:
+                    _us, _vs = [], []
+                    for _line in _mf:
+                        if _line.startswith('vt '):
+                            _parts = _line.split()
+                            _us.append(float(_parts[1]))
+                            _vs.append(float(_parts[2]))
+                    if _us:
+                        uv_u_range = max(_us) - min(_us)
+                        uv_v_range = max(_vs) - min(_vs)
+            except Exception:
+                pass
 
-        tex_path, pattern_name, pattern_params = generate_random_albedo_map(frame_str)
+            desired_repeats = random.uniform(3.0, 6.0)
 
-        # Analyse mesh UV range to choose a tiling factor that makes the pattern
-        # repeat at a visually sensible scale regardless of how the OBJ was UV-unwrapped.
-        uv_u_range, uv_v_range = 1.0, 1.0
-        try:
-            with open(current_mesh_path) as _mf:
-                _us, _vs = [], []
-                for _line in _mf:
-                    if _line.startswith('vt '):
-                        _parts = _line.split()
-                        _us.append(float(_parts[1]))
-                        _vs.append(float(_parts[2]))
-                if _us:
-                    uv_u_range = max(_us) - min(_us)
-                    uv_v_range = max(_vs) - min(_vs)
-        except Exception:
-            pass
+            material_pattern_cache[cache_key] = {
+                'material_desc':   material_desc,
+                'roughness':       _sample('roughness'),
+                'specular':        _sample('specular'),
+                'sheen':           _sample('sheen'),
+                'sheen_tint':      _sample('sheen_tint'),
+                'anisotropic':     _sample('anisotropic'),
+                'spec_trans':      _sample('spec_trans'),
+                'clearcoat':       _sample('clearcoat'),
+                'tex_path':        tex_path,
+                'pattern_name':    pattern_name,
+                'pattern_params':  pattern_params,
+                'tile_u':          desired_repeats / max(uv_u_range, 0.01),
+                'tile_v':          desired_repeats / max(uv_v_range, 0.01),
+            }
 
-        desired_repeats = random.uniform(3.0, 6.0)
-        tile_u = desired_repeats / max(uv_u_range, 0.01)
-        tile_v = desired_repeats / max(uv_v_range, 0.01)
+        mp = material_pattern_cache[cache_key]
+        material_desc   = mp['material_desc']
+        roughness       = mp['roughness']
+        specular        = mp['specular']
+        sheen           = mp['sheen']
+        sheen_tint      = mp['sheen_tint']
+        anisotropic     = mp['anisotropic']
+        spec_trans      = mp['spec_trans']
+        clearcoat       = mp['clearcoat']
+        tex_path        = mp['tex_path']
+        pattern_name    = mp['pattern_name']
+        pattern_params  = mp['pattern_params']
+        tile_u          = mp['tile_u']
+        tile_v          = mp['tile_v']
+        keyword         = f"{material_desc} pattern"
+        prompt = (
+            f"a photorealistic 3D render of a {material_desc} cloth with "
+            f"{pattern_name} pattern, physical rendering, detailed fabric folds"
+        )
 
         base_color_spec = {
             'type': 'bitmap',
@@ -435,11 +515,6 @@ def run_generation(variations_per_mesh: int = 3) -> None:
             'wrap_mode': 'repeat',
             'to_uv': mi.ScalarTransform3f.scale([tile_u, tile_v]),
         }
-
-        prompt = (
-            f"a photorealistic 3D render of a {material_desc} cloth with "
-            f"{pattern_name} pattern, physical rendering, detailed fabric folds"
-        )
 
         # -----------------------------------------------------------------------
         # Build Mitsuba Scene
@@ -692,7 +767,8 @@ def run_generation(variations_per_mesh: int = 3) -> None:
             # ── Mesh / material+pattern / view / sample hierarchy ──
             "frame_id":                  frame_id,
             "mesh_idx":                  mesh_idx,
-            "variation_idx":             variation_idx,
+            "material_idx":              material_idx,
+            "lighting_idx":              lighting_idx,
             "mesh_dir_name":             sample_parts["mesh_dir_name"],
             "material_pattern_dir_name": sample_parts["material_pattern_dir_name"],
             "view_idx":                  view_idx,

--- a/cloth_pipeline/dataset/render_loop.py
+++ b/cloth_pipeline/dataset/render_loop.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from cloth_pipeline.dataset.textures import generate_random_albedo_map
 from cloth_pipeline.paths import (
+    BASE_DIR,
     DATASET_DIR,
     DEPTH_DIR,
     FRONT_PREVIEW_DIR,
@@ -21,12 +22,12 @@ from cloth_pipeline.paths import (
     MESHES_DIR,
     METADATA_PATH,
     NORMALS_DIR,
-    PBR_ALBEDO_DIR,
-    PBR_NORMAL_DIR,
-    PBR_ROUGHNESS_DIR,
+    OUTPUTS_DIR,
     RENDERS_DIR,
     ensure_dataset_stage_dirs,
     ensure_front_preview_dir,
+    output_sample_dir,
+    sample_dir_components,
 )
 
 mi.set_variant("scalar_rgb")
@@ -143,13 +144,10 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
 
     existing = sum(
         1 for j in range(num_samples)
-        if os.path.exists(os.path.join(RENDERS_DIR,       f"render_{j:04d}.png"))
-        and os.path.exists(os.path.join(DEPTH_DIR,        f"depth_{j:04d}.npy"))
-        and os.path.exists(os.path.join(NORMALS_DIR,      f"normals_{j:04d}.npy"))
-        and os.path.exists(os.path.join(MASKS_DIR,        f"mask_{j:04d}.png"))
-        and os.path.exists(os.path.join(PBR_ALBEDO_DIR,   f"albedo_{j:04d}.png"))
-        and os.path.exists(os.path.join(PBR_ROUGHNESS_DIR, f"roughness_{j:04d}.png"))
-        and os.path.exists(os.path.join(PBR_NORMAL_DIR,   f"normal_{j:04d}.png"))
+        if os.path.exists(os.path.join(RENDERS_DIR,  f"render_{j:04d}.png"))
+        and os.path.exists(os.path.join(DEPTH_DIR,   f"depth_{j:04d}.npy"))
+        and os.path.exists(os.path.join(NORMALS_DIR, f"normals_{j:04d}.npy"))
+        and os.path.exists(os.path.join(MASKS_DIR,   f"mask_{j:04d}.png"))
     )
     print(f"Checkpoint: {existing}/{num_samples} frames already done, resuming.\n")
     print(
@@ -164,29 +162,29 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
     )
 
     for i in range(num_samples):
-        frame_str          = f"{i:04d}"
-        render_path        = os.path.join(RENDERS_DIR,        f"render_{frame_str}.png")
-        depth_path         = os.path.join(DEPTH_DIR,          f"depth_{frame_str}.npy")
-        normals_path       = os.path.join(NORMALS_DIR,        f"normals_{frame_str}.npy")
-        mask_path          = os.path.join(MASKS_DIR,          f"mask_{frame_str}.png")
-        pbr_albedo_path    = os.path.join(PBR_ALBEDO_DIR,     f"albedo_{frame_str}.png")
-        pbr_roughness_path = os.path.join(PBR_ROUGHNESS_DIR,  f"roughness_{frame_str}.png")
-        pbr_normal_path    = os.path.join(PBR_NORMAL_DIR,     f"normal_{frame_str}.png")
+        frame_str    = f"{i:04d}"
+        render_path  = os.path.join(RENDERS_DIR,  f"render_{frame_str}.png")
+        depth_path   = os.path.join(DEPTH_DIR,    f"depth_{frame_str}.npy")
+        normals_path = os.path.join(NORMALS_DIR,  f"normals_{frame_str}.npy")
+        mask_path    = os.path.join(MASKS_DIR,    f"mask_{frame_str}.png")
 
-        # --- CHECKPOINT: skip frames that are fully complete (and have metadata) ---
-        if (os.path.exists(render_path)
+        # --- CHECKPOINT: skip when intermediates + recorded PBR sample dir
+        # all exist. The mesh+material+pattern combination chosen for a frame
+        # is random, so we read the recorded paths straight from metadata. ---
+        if (frame_str in existing_metadata
+                and os.path.exists(render_path)
                 and os.path.exists(depth_path)
                 and os.path.exists(normals_path)
-                and os.path.exists(mask_path)
-                and os.path.exists(pbr_albedo_path)
-                and os.path.exists(pbr_roughness_path)
-                and os.path.exists(pbr_normal_path)):
-            if frame_str in existing_metadata:
-                metadata_records.append(existing_metadata[frame_str])
+                and os.path.exists(mask_path)):
+            rec = existing_metadata[frame_str]
+            rec_paths = [rec.get("pbr_albedo"), rec.get("pbr_normal"), rec.get("pbr_roughness")]
+            if all(rec_paths) and all(
+                os.path.exists(os.path.join(BASE_DIR, p)) for p in rec_paths
+            ):
+                metadata_records.append(rec)
                 print(f"  [{i+1:>4}/{num_samples}] Skipping {frame_str} (already exists)")
                 continue
-            # No metadata for this frame — must re-render to populate it
-            print(f"  [{i+1:>4}/{num_samples}] Re-rendering {frame_str} (missing metadata)")
+            print(f"  [{i+1:>4}/{num_samples}] Re-rendering {frame_str} (PBR outputs missing)")
 
         print(
             f"  [{i+1:>4}/{num_samples}] Frame {frame_str}: setup (mesh, lights, materials)…",
@@ -591,13 +589,27 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
         np.save(normals_path, normals_np.astype(np.float32))
 
         # -----------------------------------------------------------------------
-        # PBR ground-truth maps (Hybrid A + C)
-        #   • albedo  → Mitsuba aov:albedo channels 8-10 (linear RGB), masked
-        #   • normal  → re-encode normals_np from [-1,1] → [0,255] RGB, masked
-        #   • roughness → uniform fill from BSDF scalar × mask (Design C, post-hoc)
-        # All three are masked so the background is black and the cloth pixels
-        # carry the GT values. They share the camera/resolution of `render_path`.
+        # PBR ground-truth maps → outputs/mesh_<stem>/<material>_<pattern>/view_<idx>/sample_<frame>/
+        #   • albedo.png    → Mitsuba aov:albedo channels 8-10 (linear RGB), masked
+        #   • normal.png    → re-encode normals_np from [-1,1] → [0,255] RGB, masked
+        #   • roughness.png → uniform fill from BSDF scalar × mask (Design C, post-hoc)
+        # The per-sample frame folder makes every frame collision-free, so two
+        # frames picking the same (mesh, material, pattern, view) live side by
+        # side as different lighting variations.
         # -----------------------------------------------------------------------
+        view_idx = 0  # multi-view rendering not implemented yet
+        frame_id = i
+        sample_parts = sample_dir_components(
+            current_mesh_path, material_desc, pattern_name, view_idx, frame_id
+        )
+        sample_out_dir = output_sample_dir(
+            current_mesh_path, material_desc, pattern_name, view_idx, frame_id
+        )
+        os.makedirs(sample_out_dir, exist_ok=True)
+        pbr_albedo_path    = os.path.join(sample_out_dir, "albedo.png")
+        pbr_normal_path    = os.path.join(sample_out_dir, "normal.png")
+        pbr_roughness_path = os.path.join(sample_out_dir, "roughness.png")
+
         if render_np.shape[2] >= 11:
             albedo_np = np.clip(render_np[:, :, 8:11], 0.0, 1.0)
         else:
@@ -663,10 +675,19 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
             "pattern_params":     pattern_params,
             "albedo_map":         f"textures/texture_{frame_str}.png",
             "albedo_tiling":      [tile_u, tile_v],
-            # ── PBR ground-truth maps (pixel-aligned with renders/sketches) ──
-            "pbr_albedo":         f"pbr/albedo/albedo_{frame_str}.png",
-            "pbr_roughness":      f"pbr/roughness/roughness_{frame_str}.png",
-            "pbr_normal":         f"pbr/normal/normal_{frame_str}.png",
+            # ── Mesh / material+pattern / view / sample hierarchy ──
+            "frame_id":                  frame_id,
+            "mesh_dir_name":             sample_parts["mesh_dir_name"],
+            "material_pattern_dir_name": sample_parts["material_pattern_dir_name"],
+            "view_idx":                  view_idx,
+            "sample_dir_name":           sample_parts["sample_dir_name"],
+            "sample_output_dir":         os.path.relpath(sample_out_dir, BASE_DIR),
+            "pbr_albedo":                os.path.relpath(pbr_albedo_path,    BASE_DIR),
+            "pbr_roughness":             os.path.relpath(pbr_roughness_path, BASE_DIR),
+            "pbr_normal":                os.path.relpath(pbr_normal_path,    BASE_DIR),
+            "sketch_path":               os.path.relpath(
+                os.path.join(sample_out_dir, "sketch.png"), BASE_DIR
+            ),
         })
 
         light_types_str = ', '.join(lm['type'] for lm in lights_meta)
@@ -689,11 +710,9 @@ def run_generation(num_samples: int = 3) -> None:  # bump for full training runs
     print(f"  • beauty PNGs   → {RENDERS_DIR}")
     print(f"  • depth .npy    → {DEPTH_DIR}")
     print(f"  • normal .npy   → {NORMALS_DIR}")
-    print(f"  • PBR albedo    → {PBR_ALBEDO_DIR}")
-    print(f"  • PBR roughness → {PBR_ROUGHNESS_DIR}")
-    print(f"  • PBR normal    → {PBR_NORMAL_DIR}")
+    print(f"  • PBR maps      → {OUTPUTS_DIR}/mesh_<stem>/<mat>_<pat>/view_0/sample_NNNN/")
     print(f"  • metadata      → {METADATA_PATH}")
-    print("\nNext: run  python generate_sketches.py  to run Neural Contours inference.")
+    print("\nNext: run  python generate_sketches.py  to write sketch.png next to PBR maps.")
 
 
 def run_front_mesh_previews(*, only_stem: str | None = None) -> None:

--- a/cloth_pipeline/paths.py
+++ b/cloth_pipeline/paths.py
@@ -1,6 +1,7 @@
 """Project-root paths used by Stage 1 (dataset) and Stage 2 (sketches)."""
 
 import os
+import re
 
 _PKG_DIR = os.path.dirname(os.path.abspath(__file__))
 BASE_DIR = os.path.dirname(_PKG_DIR)
@@ -14,30 +15,69 @@ MASKS_DIR = os.path.join(DATASET_DIR, "masks")
 # Procedural albedo / pattern maps (Mitsuba base_color). Folder name is historical.
 ALBEDO_MAPS_DIR = os.path.join(DATASET_DIR, "textures")
 TEXTURES_DIR = ALBEDO_MAPS_DIR  # deprecated alias — same path as ALBEDO_MAPS_DIR
-CONDITION_DIR = os.path.join(DATASET_DIR, "conditioning")
 METADATA_PATH = os.path.join(DATASET_DIR, "metadata.jsonl")
 FRONT_PREVIEW_DIR = os.path.join(DATASET_DIR, "front_previews")
 
-# PBR ground-truth maps, pixel-aligned with renders/sketches.
-# Albedo + normal come from the Mitsuba AOV pass; roughness is a post-hoc
-# uniform fill from material_props (single BSDF per garment for now).
-PBR_DIR = os.path.join(DATASET_DIR, "pbr")
-PBR_ALBEDO_DIR = os.path.join(PBR_DIR, "albedo")
-PBR_ROUGHNESS_DIR = os.path.join(PBR_DIR, "roughness")
-PBR_NORMAL_DIR = os.path.join(PBR_DIR, "normal")
+# Training-ready outputs (sketch + PBR maps), grouped per mesh / view.
+# Stage 1 writes albedo/normal/roughness here; Stage 2 writes sketch here.
+# Layout: outputs/mesh_<sanitized_stem>/view_<idx>/{sketch,albedo,normal,roughness}.png
+OUTPUTS_DIR = os.path.join(BASE_DIR, "outputs")
+
+
+def sanitize_mesh_name(stem: str) -> str:
+    """Lowercase + collapse non-alphanumeric runs to underscores; strip edges.
+    Generic enough to use for any path component (mesh, material, pattern)."""
+    s = stem.lower()
+    s = re.sub(r"[^a-z0-9]+", "_", s)
+    return s.strip("_")
+
+
+def sample_dir_components(
+    mesh_path: str,
+    material_type: str,
+    pattern_name: str,
+    view_idx: int,
+    frame_id: int,
+) -> dict:
+    """Named pieces of the per-sample output directory; mirror these into metadata."""
+    mesh_stem = os.path.splitext(os.path.basename(mesh_path))[0]
+    return {
+        "mesh_dir_name": f"mesh_{sanitize_mesh_name(mesh_stem)}",
+        "material_pattern_dir_name": (
+            f"{sanitize_mesh_name(material_type)}_{sanitize_mesh_name(pattern_name)}"
+        ),
+        "view_idx": int(view_idx),
+        "sample_dir_name": f"sample_{int(frame_id):04d}",
+    }
+
+
+def output_sample_dir(
+    mesh_path: str,
+    material_type: str,
+    pattern_name: str,
+    view_idx: int,
+    frame_id: int,
+) -> str:
+    """Absolute path to the per-(mesh, material+pattern, view, frame) directory."""
+    parts = sample_dir_components(mesh_path, material_type, pattern_name, view_idx, frame_id)
+    return os.path.join(
+        OUTPUTS_DIR,
+        parts["mesh_dir_name"],
+        parts["material_pattern_dir_name"],
+        f"view_{parts['view_idx']}",
+        parts["sample_dir_name"],
+    )
 
 
 def ensure_dataset_stage_dirs() -> None:
+    """Create flat intermediate dirs + the outputs/ root (per-mesh subdirs are
+    created on demand at write time)."""
     for d in (
-        RENDERS_DIR, DEPTH_DIR, NORMALS_DIR, MASKS_DIR, MESHES_DIR, ALBEDO_MAPS_DIR,
-        PBR_ALBEDO_DIR, PBR_ROUGHNESS_DIR, PBR_NORMAL_DIR,
+        RENDERS_DIR, DEPTH_DIR, NORMALS_DIR, MASKS_DIR, MESHES_DIR,
+        ALBEDO_MAPS_DIR, OUTPUTS_DIR,
     ):
         os.makedirs(d, exist_ok=True)
 
 
 def ensure_front_preview_dir() -> None:
     os.makedirs(FRONT_PREVIEW_DIR, exist_ok=True)
-
-
-def ensure_sketch_stage_dirs() -> None:
-    os.makedirs(CONDITION_DIR, exist_ok=True)

--- a/cloth_pipeline/paths.py
+++ b/cloth_pipeline/paths.py
@@ -18,9 +18,20 @@ CONDITION_DIR = os.path.join(DATASET_DIR, "conditioning")
 METADATA_PATH = os.path.join(DATASET_DIR, "metadata.jsonl")
 FRONT_PREVIEW_DIR = os.path.join(DATASET_DIR, "front_previews")
 
+# PBR ground-truth maps, pixel-aligned with renders/sketches.
+# Albedo + normal come from the Mitsuba AOV pass; roughness is a post-hoc
+# uniform fill from material_props (single BSDF per garment for now).
+PBR_DIR = os.path.join(DATASET_DIR, "pbr")
+PBR_ALBEDO_DIR = os.path.join(PBR_DIR, "albedo")
+PBR_ROUGHNESS_DIR = os.path.join(PBR_DIR, "roughness")
+PBR_NORMAL_DIR = os.path.join(PBR_DIR, "normal")
+
 
 def ensure_dataset_stage_dirs() -> None:
-    for d in (RENDERS_DIR, DEPTH_DIR, NORMALS_DIR, MASKS_DIR, MESHES_DIR, ALBEDO_MAPS_DIR):
+    for d in (
+        RENDERS_DIR, DEPTH_DIR, NORMALS_DIR, MASKS_DIR, MESHES_DIR, ALBEDO_MAPS_DIR,
+        PBR_ALBEDO_DIR, PBR_ROUGHNESS_DIR, PBR_NORMAL_DIR,
+    ):
         os.makedirs(d, exist_ok=True)
 
 

--- a/cloth_pipeline/sketch/pipeline.py
+++ b/cloth_pipeline/sketch/pipeline.py
@@ -1,4 +1,9 @@
-"""Render → conditioning sketch (edges, silhouette, hatching, labels)."""
+"""Render → conditioning sketch (edges, silhouette, hatching, glyphs).
+
+Returns a raw render-sized BGR canvas so the sketch is pixel-aligned with the
+beauty render and PBR maps. The decorated text-band variant has been retired
+along with the legacy ``dataset/conditioning/`` output.
+"""
 
 from __future__ import annotations
 
@@ -6,84 +11,23 @@ import os
 
 import cv2
 import numpy as np
-from PIL import Image, ImageDraw
 
 from cloth_pipeline.paths import DATASET_DIR
-from cloth_pipeline.sketch.constants import SKETCH_BGR, SKETCH_RGB, USE_TEXTURE_STROKES
+from cloth_pipeline.sketch.constants import SKETCH_BGR, USE_TEXTURE_STROKES
 from cloth_pipeline.sketch.drawing import (
     albedo_pattern_stroke_mask,
-    draw_annotations,
     draw_depth_layer_boundary,
     draw_occlusion_edges,
     draw_shade_marks,
     draw_wobbly_contour,
-    measure_top_left_text_pad,
 )
 from cloth_pipeline.sketch.edges import detect_edges
-from cloth_pipeline.sketch.features import detect_dominant_color, find_feature_points
+from cloth_pipeline.sketch.features import find_feature_points
 from cloth_pipeline.sketch.segmentation import get_object_mask
 
 
-def _nonwhite_bbox(img_bgr: np.ndarray, threshold: int = 250) -> tuple[int, int, int, int] | None:
-    gray = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2GRAY)
-    ys, xs = np.where(gray < threshold)
-    if ys.size == 0:
-        return None
-    return int(xs.min()), int(ys.min()), int(xs.max()), int(ys.max())
-
-
-def _place_scaled_content(
-    content_bgr: np.ndarray,
-    out_w: int,
-    out_h: int,
-    *,
-    pad_left: int,
-    pad_top: int,
-    pad_right: int,
-    pad_bottom: int,
-) -> np.ndarray:
-    """
-    Crop to the inked sketch region, scale it up moderately, and place it in
-    the drawable area that remains after reserving the top-left text block.
-    """
-    full = np.full((out_h, out_w, 3), 255, dtype=np.uint8)
-    bbox = _nonwhite_bbox(content_bgr)
-    if bbox is None:
-        full[pad_top : pad_top + content_bgr.shape[0], pad_left : pad_left + content_bgr.shape[1]] = content_bgr
-        return full
-
-    x0, y0, x1, y1 = bbox
-    crop = content_bgr[y0 : y1 + 1, x0 : x1 + 1]
-    ch, cw = crop.shape[:2]
-
-    avail_x0 = max(18, pad_left + 12)
-    avail_y0 = max(18, pad_top + 10)
-    avail_x1 = max(avail_x0 + 1, out_w - pad_right + max(18, pad_right // 3))
-    avail_y1 = max(avail_y0 + 1, out_h - pad_bottom + max(18, pad_bottom // 3))
-    avail_w = max(1, avail_x1 - avail_x0)
-    avail_h = max(1, avail_y1 - avail_y0)
-
-    scale = min(avail_w / float(max(1, cw)), avail_h / float(max(1, ch)), 1.45)
-    if scale <= 0:
-        scale = 1.0
-    new_w = max(1, int(round(cw * scale)))
-    new_h = max(1, int(round(ch * scale)))
-    interp = cv2.INTER_CUBIC if scale > 1.0 else cv2.INTER_AREA
-    placed = cv2.resize(crop, (new_w, new_h), interpolation=interp)
-
-    off_x = avail_x0 + max(0, (avail_w - new_w) // 2)
-    off_y = avail_y0 + max(0, (avail_h - new_h) // 2)
-    region = full[off_y : off_y + new_h, off_x : off_x + new_w]
-    gray = cv2.cvtColor(placed, cv2.COLOR_BGR2GRAY)
-    ink = gray < 250
-    region[ink] = placed[ink]
-    return full
-
 def generate_sketch(
     render_path:    str,
-    obj_name:       str,
-    material_label: str,
-    texture_label:  str,
     *,
     alpha_mask_path: str | None = None,
     albedo_map_path: str | None = None,
@@ -91,19 +35,11 @@ def generate_sketch(
     pattern_name:    str | None = None,
 ) -> np.ndarray:
     """
-    Full render → conditioning sketch pipeline.
+    Render → render-sized BGR sketch canvas (no text band, no rescaling).
 
-    When ``albedo_map_path`` / ``albedo_tiling`` / ``pattern_name`` are set (from
-    dataset metadata), the same procedural albedo PNG used for Mitsuba ``base_color``
-    is tiled and converted to sparse in-mask strokes so pattern is separate from
-    lighting-dependent structure in the RGB render.
-
-    Fabric preset is written in the top-left text block (``material_label``), not
-    as strokes on the cloth. The output canvas adds equal padding on opposite sides
-    (right = left, bottom = top) so the ``w×h`` sketch stays **centred** like the
-    source render, while the top-left quadrant stays clear for captions.
-
-    Returns a BGR uint8 image ready for cv2.imwrite.
+    The returned canvas matches ``render_path``'s width/height exactly, so the
+    sketch is pixel-aligned with the beauty render and the PBR maps written by
+    Stage 1 to ``outputs/<mesh>/view_<idx>/``.
     """
     # Load as BGRA so we can extract the alpha channel saved by generate_dataset.
     # cv2.IMREAD_UNCHANGED preserves all 4 channels when they exist.
@@ -203,50 +139,5 @@ def generate_sketch(
 
     features_pts = find_feature_points(img_bgr, seg_mask)
     draw_shade_marks(canvas, features_pts, SKETCH_BGR)
-
-    # ── Colour detection for text ─────────────────────────────────────────────
-    dominant_color = detect_dominant_color(img_bgr, seg_mask)
-
-    # ── D: Annotation + reserved top-left band ───────────────────────────────
-    mat_display = (
-        material_label.replace(" texture", "").replace(" Texture", "")
-        .replace("Coarse ", "").replace("coarse ", "")
-        .strip()
-    )
-    short_name = obj_name.replace("Wool ", "").replace("wool ", "")
-    text_lines = [
-        f"Material: {mat_display}",
-        f"Object: {short_name} ({dominant_color})",
-        f"Texture: {texture_label}",
-    ]
-    pad_left, pad_top = measure_top_left_text_pad(text_lines)
-    # Keep a generous text band at top-left, but trim the opposite margins so
-    # the scarf takes up more of the page than in earlier versions.
-    pad_right = max(44, int(round(pad_left * 0.42)))
-    pad_bottom = max(40, int(round(pad_top * 0.35)))
-    out_w = pad_left + w + pad_right
-    out_h = pad_top + h + pad_bottom
-    full = _place_scaled_content(
-        canvas,
-        out_w,
-        out_h,
-        pad_left=pad_left,
-        pad_top=pad_top,
-        pad_right=pad_right,
-        pad_bottom=pad_bottom,
-    )
-
-    pil = Image.fromarray(cv2.cvtColor(full, cv2.COLOR_BGR2RGB))
-    draw = ImageDraw.Draw(pil)
-
-    draw_annotations(
-        draw,
-        text_lines,
-        {},
-        canvas_wh=(out_w, out_h),
-        color=SKETCH_RGB,
-        sketch_content_top=pad_top,
-    )
-    canvas = cv2.cvtColor(np.array(pil), cv2.COLOR_RGB2BGR)
 
     return canvas

--- a/cloth_pipeline/sketch/runner.py
+++ b/cloth_pipeline/sketch/runner.py
@@ -1,4 +1,4 @@
-"""Batch over metadata.jsonl → conditioning images."""
+"""Batch over metadata.jsonl → outputs/<mesh>/view_<idx>/sketch.png."""
 
 from __future__ import annotations
 
@@ -7,25 +7,8 @@ import os
 
 import cv2
 
-from cloth_pipeline.paths import CONDITION_DIR, DATASET_DIR, METADATA_PATH, ensure_sketch_stage_dirs
+from cloth_pipeline.paths import BASE_DIR, DATASET_DIR, METADATA_PATH
 from cloth_pipeline.sketch.pipeline import generate_sketch
-
-
-def _material_label_from_meta(meta: dict) -> str:
-    """Human-readable fabric preset (BRDF category), not albedo pattern."""
-    mt = meta.get("material_type")
-    if mt:
-        s = str(mt).replace("_", " ").strip()
-        return s[0].upper() + s[1:] if s else "Fabric"
-    legacy = meta.get("texture_type")
-    if legacy:
-        return (
-            str(legacy)
-            .replace(" texture", "")
-            .replace(" Texture", "")
-            .strip()
-        )
-    return "Wool"
 
 
 def _albedo_rel_from_meta(meta: dict) -> str | None:
@@ -44,46 +27,31 @@ def _pattern_name_from_meta(meta: dict) -> str | None:
     return meta.get("pattern_name") or meta.get("texture_pattern")
 
 
-def _texture_label_from_meta(meta: dict) -> str:
-    """Caption for the third annotation line (pattern-first, e.g. Stripes)."""
-    raw = _pattern_name_from_meta(meta)
-    if raw is not None and str(raw).strip():
-        s = str(raw).replace("_", " ").strip()
-        return s.title() if s else "Plain"
-    kw = meta.get("keyword")
-    if kw is not None and str(kw).strip():
-        return str(kw).strip()
-    return "Plain"
-
-
-def run_from_metadata(*, output_dir: str | None = None) -> None:
-    ensure_sketch_stage_dirs()
-    condition_dir = output_dir or CONDITION_DIR
-    os.makedirs(condition_dir, exist_ok=True)
-
-    if os.path.exists(METADATA_PATH):
-        with open(METADATA_PATH) as f:
-            records = [json.loads(ln) for ln in f if ln.strip()]
-    else:
-        records = []
+def run_from_metadata() -> None:
+    if not os.path.exists(METADATA_PATH):
         print(f"[WARNING] metadata.jsonl not found at {METADATA_PATH}.")
         print("  Run generate_dataset.py first, then re-run this script.")
+        return
+
+    with open(METADATA_PATH) as f:
+        records = [json.loads(ln) for ln in f if ln.strip()]
 
     for meta in records:
         frame_str   = meta["frame"]
         render_path = os.path.join(
             DATASET_DIR, meta.get("file_name", f"renders/render_{frame_str}.png")
         )
-        out_path = os.path.join(condition_dir, f"conditioning_{frame_str}.png")
+
+        sketch_rel = meta.get("sketch_path")
+        if not sketch_rel:
+            print(f"  [{frame_str}] [SKIP] sketch_path missing — re-run generate_dataset.py.")
+            continue
+        out_path = os.path.join(BASE_DIR, sketch_rel)
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
 
         if os.path.exists(out_path):
             print(f"  [{frame_str}] Skipping (already exists)")
             continue
-
-        raw_text = meta.get("text", "")
-        texture_label = _texture_label_from_meta(meta)
-        material_label = _material_label_from_meta(meta)
-        obj_name = "Wool Scarf" if "wool" in raw_text.lower() else "Cloth"
 
         tex_rel = _albedo_rel_from_meta(meta)
         albedo_map_path = (
@@ -97,9 +65,6 @@ def run_from_metadata(*, output_dir: str | None = None) -> None:
         try:
             sketch = generate_sketch(
                 render_path,
-                obj_name,
-                material_label,
-                texture_label,
                 alpha_mask_path=alpha_mask_path,
                 albedo_map_path=albedo_map_path,
                 albedo_tiling=_albedo_tiling_from_meta(meta),

--- a/generate_dataset.py
+++ b/generate_dataset.py
@@ -30,8 +30,15 @@ if __name__ == "__main__":
         default=None,
         help="With --front-previews: only render cloth_meshes/STEM.obj (no .obj suffix).",
     )
+    parser.add_argument(
+        "--variations-per-mesh",
+        type=int,
+        default=3,
+        metavar="N",
+        help="Number of randomised variations per mesh (default: 3).",
+    )
     args = parser.parse_args()
     if args.front_previews:
         run_front_mesh_previews(only_stem=args.front_preview_only)
     else:
-        run_generation()
+        run_generation(variations_per_mesh=args.variations_per_mesh)

--- a/generate_dataset.py
+++ b/generate_dataset.py
@@ -31,14 +31,24 @@ if __name__ == "__main__":
         help="With --front-previews: only render cloth_meshes/STEM.obj (no .obj suffix).",
     )
     parser.add_argument(
-        "--variations-per-mesh",
+        "--materials-per-mesh",
         type=int,
         default=3,
         metavar="N",
-        help="Number of randomised variations per mesh (default: 3).",
+        help="Number of (material, pattern) combinations per mesh (default: 3).",
+    )
+    parser.add_argument(
+        "--lightings-per-material",
+        type=int,
+        default=2,
+        metavar="N",
+        help="Number of lighting variations per (mesh, material, pattern) (default: 2).",
     )
     args = parser.parse_args()
     if args.front_previews:
         run_front_mesh_previews(only_stem=args.front_preview_only)
     else:
-        run_generation(variations_per_mesh=args.variations_per_mesh)
+        run_generation(
+            materials_per_mesh=args.materials_per_mesh,
+            lightings_per_material=args.lightings_per_material,
+        )

--- a/generate_sketches.py
+++ b/generate_sketches.py
@@ -1,7 +1,8 @@
 """
 generate_sketches.py
 --------------------
-Stage 2: Mitsuba renders → aligned sketch conditioning images.
+Stage 2: Mitsuba renders → aligned sketch images written to
+``outputs/<mesh>/view_<idx>/sketch.png`` next to the PBR maps from Stage 1.
 
 The CV pipeline is split under ``cloth_pipeline.sketch`` (edges, segmentation,
 shadows, features, drawing, batch runner). Run from project root:
@@ -11,16 +12,7 @@ shadows, features, drawing, batch runner). Run from project root:
 See module docstrings there for HED/SAM optional models and env vars.
 """
 
-import argparse
-
 from cloth_pipeline.sketch import run_from_metadata
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Generate conditioning sketches from renders.")
-    parser.add_argument(
-        "--output-dir",
-        default=None,
-        help="Output directory for conditioning images (default: dataset/conditioning).",
-    )
-    args = parser.parse_args()
-    run_from_metadata(output_dir=args.output_dir)
+    run_from_metadata()


### PR DESCRIPTION
## Summary
Replaces per-frame `random.choice(mesh_files)` with a deterministic mesh×variation grid. Every mesh in `cloth_meshes/` (sorted) gets exactly `variations_per_mesh` frames. Material / BRDF parameters / pattern / lighting are still randomised per variation, so each mesh ends up covered by N distinct lighting+material samples — the disentanglement scenario we want for training.

Builds on top of #12. Includes the full chain: PBR maps (#11) + outputs/ hierarchy (#12) + this mesh iteration.

## Changes
- `run_generation(variations_per_mesh=3)` (was `num_samples=3`). Total frames = `N_meshes × variations_per_mesh`. Prints `"Generating X meshes × Y variations = Z samples"` at start.
- Mesh selection now `mesh_files[i // variations_per_mesh]`; the loop body is otherwise unchanged.
- `NECH_ONLY_FRAME` + `NECH_FORCE_MESH_STEM` env override still pins a specific frame to a specific mesh stem (for re-rendering one frame).
- Metadata adds `mesh_idx` and `variation_idx` per frame for traceability.
- `generate_dataset.py` gains `--variations-per-mesh N` (default 3).

## Test plan
- [x] `rm -rf dataset/ outputs/`
- [x] `python3 generate_dataset.py` — 6 meshes × 3 variations = 18 samples
- [x] `python3 generate_sketches.py` — 18 sketches written
- [x] `outputs/` has 6 mesh dirs, each with exactly 3 sample folders
- [x] All 72 PNGs (18 × 4) at 512×512, no incomplete sample dirs
- [x] Same mesh's 3 variations differ visibly in material/pattern/lighting (e.g. `mesh_uploads_files_994978_scarf` rolled `leather_polkadot`, `silk_polkadot`, `wool_plaid` across its three samples)
- [ ] Visual review by @AcarBasaran before merging

## Out of scope
- Multi-view rendering (`view_0` still hardcoded; structure ready for `view_1`+)
- Spatially-varying PBR / per-region material tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)