### PR TITLE
feat(#32): CLIPTextEncoder — frozen pretrained text encoder

### DIFF
--- a/pbr_model/model.py
+++ b/pbr_model/model.py
@@ -99,13 +99,14 @@ class TextEncoder(nn.Module):
     """Toy text encoder: hash each prompt → vocab id → learned embedding → linear.
 
     Deterministic enough for scaffold smoke tests; *not* what real training will use.
-    Swap with a real text encoder (CLIP, T5, frozen BERT, etc.) — only requirement
-    is output shape ``(B, embed_dim)``.
+    Swap with ``CLIPTextEncoder`` (or another real encoder) for real training —
+    only requirement is output shape ``(B, embed_dim)``.
     """
 
     def __init__(self, embed_dim: int = 128, vocab_size: int = 10_000) -> None:
         super().__init__()
         self.vocab_size = vocab_size
+        self.embed_dim = embed_dim
         self.emb = nn.Embedding(vocab_size, embed_dim)
         self.proj = nn.Linear(embed_dim, embed_dim)
 
@@ -122,6 +123,59 @@ class TextEncoder(nn.Module):
         )
         embs = self.emb(ids).mean(dim=1)  # (B, D)
         return F.relu(self.proj(embs))
+
+
+class CLIPTextEncoder(nn.Module):
+    """Frozen CLIP text encoder for real training (issue #32).
+
+    Wraps ``transformers.CLIPTextModel`` + ``CLIPTokenizer``. Pretrained on
+    400M (image, text) pairs, so prompts like "houndstooth pattern", "silk",
+    "draped" already carry visually-grounded meaning before our network ever
+    starts training.
+
+    - First call downloads ~250 MB to ``~/.cache/huggingface/`` (offline thereafter).
+    - Frozen — no gradient flows into CLIP. It's a fixed feature extractor.
+    - Output shape: ``(B, embed_dim)`` where embed_dim = 512 for ViT-B/32.
+
+    Drop-in replacement for ``TextEncoder``: same forward signature ``(list[str]) → (B, D)``.
+    """
+
+    def __init__(self, model_name: str = "openai/clip-vit-base-patch32") -> None:
+        super().__init__()
+        try:
+            from transformers import CLIPTextModel, CLIPTokenizer
+        except ImportError as e:
+            raise ImportError(
+                "CLIPTextEncoder requires the `transformers` package. "
+                "Install with: python3 -m pip install transformers"
+            ) from e
+        self.tokenizer = CLIPTokenizer.from_pretrained(model_name)
+        self.text_model = CLIPTextModel.from_pretrained(model_name)
+        # Freeze: no gradient through CLIP at training time.
+        for p in self.text_model.parameters():
+            p.requires_grad = False
+        self.text_model.eval()
+        self.embed_dim = self.text_model.config.hidden_size  # 512 for ViT-B/32
+
+    def forward(self, prompts: list[str]) -> torch.Tensor:
+        device = next(self.text_model.parameters()).device
+        tokens = self.tokenizer(
+            prompts,
+            padding=True,
+            truncation=True,
+            max_length=77,  # CLIP's standard context length
+            return_tensors="pt",
+        ).to(device)
+        with torch.no_grad():  # belt-and-suspenders: requires_grad already False
+            out = self.text_model(**tokens)
+        # ``pooler_output`` is the EOT-token embedding — CLIP's standard sentence vector.
+        return out.pooler_output  # (B, embed_dim)
+
+    def train(self, mode: bool = True) -> "CLIPTextEncoder":
+        # Override: keep CLIP in eval mode regardless of parent module's train()/eval().
+        super().train(mode)
+        self.text_model.eval()
+        return self
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +197,8 @@ class PBRModel(nn.Module):
         variant: Literal["a", "b"] = "a",
         base_channels: int = 32,
         text_dim: int = 128,
+        use_clip: bool = False,
+        clip_model: str = "openai/clip-vit-base-patch32",
     ) -> None:
         super().__init__()
         if variant not in ("a", "b"):
@@ -158,7 +214,14 @@ class PBRModel(nn.Module):
         self.down4 = Down(c * 8, c * 16)       # bottleneck (B, 16c, H/16, W/16)
 
         # --- Text injection at the bottleneck ---
-        self.text_enc = TextEncoder(embed_dim=text_dim)
+        # use_clip=True: frozen CLIP text encoder (real training).
+        # use_clip=False: the toy stub encoder (scaffold smoke tests).
+        if use_clip:
+            self.text_enc = CLIPTextEncoder(model_name=clip_model)
+            text_dim = self.text_enc.embed_dim  # 512 for ViT-B/32
+        else:
+            self.text_enc = TextEncoder(embed_dim=text_dim)
+        self.use_clip = use_clip
         self.text_proj = nn.Linear(text_dim, c * 16)
 
         # --- Decoder ---
@@ -223,9 +286,22 @@ def make_model(
     variant: Literal["a", "b"] = "a",
     base_channels: int = 32,
     text_dim: int = 128,
+    use_clip: bool = False,
+    clip_model: str = "openai/clip-vit-base-patch32",
 ) -> PBRModel:
-    """Factory for ``PBRModel``. Mirrors ``pbr_model.dataset.make_dataloader``."""
-    return PBRModel(variant=variant, base_channels=base_channels, text_dim=text_dim)
+    """Factory for ``PBRModel``. Mirrors ``pbr_model.dataset.make_dataloader``.
+
+    ``use_clip=True`` swaps the toy stub text encoder for a frozen CLIP encoder.
+    Default is ``False`` so scaffold smoke tests stay fast and don't require
+    the ~250 MB CLIP download.
+    """
+    return PBRModel(
+        variant=variant,
+        base_channels=base_channels,
+        text_dim=text_dim,
+        use_clip=use_clip,
+        clip_model=clip_model,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -235,9 +311,18 @@ def make_model(
 
 def _smoke_test(args: argparse.Namespace) -> None:
     torch.manual_seed(0)
-    model = make_model(variant=args.variant, base_channels=args.base_channels)
+    model = make_model(
+        variant=args.variant,
+        base_channels=args.base_channels,
+        use_clip=args.use_clip,
+    )
     n_params = sum(p.numel() for p in model.parameters())
-    print(f"PBRModel(variant={args.variant!r}, base_channels={args.base_channels}) | {n_params:,} params")
+    n_train = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    text_kind = "CLIP" if args.use_clip else "stub"
+    print(
+        f"PBRModel(variant={args.variant!r}, base_channels={args.base_channels}, "
+        f"text={text_kind}) | {n_params:,} params total, {n_train:,} trainable"
+    )
 
     sketch = torch.randn(args.batch_size, 3, args.size, args.size)
     prompts = [f"cloth sample {i}" for i in range(args.batch_size)]
@@ -257,6 +342,10 @@ def main() -> None:
     parser.add_argument("--batch-size", type=int, default=2)
     parser.add_argument("--size", type=int, default=512, help="square input H=W")
     parser.add_argument("--base-channels", type=int, default=32)
+    parser.add_argument(
+        "--use-clip", action="store_true",
+        help="Use frozen CLIP text encoder instead of the toy stub. Downloads ~250 MB on first call.",
+    )
     args = parser.parse_args()
     _smoke_test(args)
 

--- a/pbr_model/train.py
+++ b/pbr_model/train.py
@@ -84,6 +84,7 @@ def train(
     steps: int = 10,
     lr: float = 1e-3,
     base_channels: int = 16,
+    use_clip: bool = False,
     lambda_roughness: float = 1.0,
     lambda_lighting: float = 0.1,
     checkpoint_path: str | Path = "checkpoints/scaffold.pt",
@@ -92,12 +93,16 @@ def train(
 ) -> dict:
     """Run a tiny training loop. Returns a dict with first/last loss + checkpoint path."""
     if verbose:
-        print(f"=== training scaffold | variant={variant} | bs={batch_size} | steps={steps} | device={device} ===")
+        text_kind = "CLIP" if use_clip else "stub"
+        print(
+            f"=== training scaffold | variant={variant} | bs={batch_size} | steps={steps} "
+            f"| text={text_kind} | device={device} ==="
+        )
 
     loader = make_dataloader(
         metadata_path=metadata_path, variant=variant, batch_size=batch_size, shuffle=True,
     )
-    model = make_model(variant=variant, base_channels=base_channels).to(device)
+    model = make_model(variant=variant, base_channels=base_channels, use_clip=use_clip).to(device)
     model.train()
     optimizer = torch.optim.Adam(model.parameters(), lr=lr)
 
@@ -178,6 +183,10 @@ def main() -> None:
     parser.add_argument("--steps", type=int, default=10)
     parser.add_argument("--lr", type=float, default=1e-3)
     parser.add_argument("--base-channels", type=int, default=16)
+    parser.add_argument(
+        "--use-clip", action="store_true",
+        help="Use frozen CLIP text encoder instead of the stub (real-training quality, ~250 MB download).",
+    )
     parser.add_argument("--lambda-roughness", type=float, default=1.0)
     parser.add_argument("--lambda-lighting", type=float, default=0.1)
     parser.add_argument("--checkpoint", default="checkpoints/scaffold.pt")
@@ -191,6 +200,7 @@ def main() -> None:
         steps=args.steps,
         lr=args.lr,
         base_channels=args.base_channels,
+        use_clip=args.use_clip,
         lambda_roughness=args.lambda_roughness,
         lambda_lighting=args.lambda_lighting,
         checkpoint_path=args.checkpoint,


### PR DESCRIPTION
## Closes #32 — stacked on #31 (training scaffold)

Swaps the toy stub TextEncoder for a frozen CLIP text encoder so prompts contribute *real* visual understanding to training, instead of random hash-table lookups.

### Why

The stub TextEncoder hashes each prompt → vocab id → learned embedding. The network has to learn from scratch what every word visually means, using only our few-thousand training samples. That's massively sample-inefficient when text understanding is *already a solved problem*.

CLIP was trained on 400M (image, caption) pairs and already knows that "houndstooth", "silk", "draped" map to specific visual concepts. Dropping it in front of the U-Net is the standard pattern across the field (Stable Diffusion, ControlNet, DALL-E, Imagen — they all do this).

### What changed

- New ``CLIPTextEncoder`` class in ``pbr_model/model.py``:
  - Wraps ``transformers.CLIPTextModel`` + ``CLIPTokenizer`` (``openai/clip-vit-base-patch32``)
  - Frozen — no gradient flows in
  - Output: ``(B, 512)`` (CLIP ViT-B/32 hidden size)
  - Drop-in replacement: same ``list[str] → (B, embed_dim)`` signature as the stub
  - ``transformers`` lazy-imported so scaffold tests don't need it
- New ``use_clip: bool = False`` flag on ``make_model()`` and ``PBRModel``
- New ``--use-clip`` CLI flag on ``pbr_model.train``
- Stub path unchanged when ``use_clip=False`` (default) — backward compatible

### Verified

```
$ python -m pbr_model.model --variant b --batch-size 2 --size 64 --base-channels 8 --use-clip
PBRModel(variant='b', base_channels=8, text=CLIP) | 63,718,923 params total, 552,971 trainable
forward(sketch=(2, 3, 64, 64), prompt=list[str]×2):
  render: (2, 3, 64, 64) torch.float32  range=[0.437, 0.611]
```

Comprehensive integration test passed:
- CLIP params: ``requires_grad=False`` on all 196 tensors ✓
- CLIP output shape: ``(2, 512)`` regardless of prompt length ✓
- Stub still works when ``use_clip=False`` ✓
- Forward+backward: U-Net receives gradients; CLIP receives zero ✓
- Trainable params: 552K of 63.7M total (0.9% — CLIP correctly frozen) ✓

### Dependency note

``transformers >= 4.45`` works with our torch 2.2.2. The ``transformers`` package is only required when ``use_clip=True`` (lazy-imported), so the scaffold smoke tests on PRs #29/#30/#31 still don't need it. First call downloads CLIP weights (~250 MB) to ``~/.cache/huggingface/``.

### What this unblocks

Real training on VALAR (#23) — without this, the model would be drastically text-blind. With it, prompts like *"silk scarf with houndstooth pattern"* contribute meaningfully from step 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)