### PR TITLE
feat: cascade #30 + #31 + #33 to main (stacked PRs got stuck on intermediate branches)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ output_meshes/
 # Scratch test files
 test_bake.py
 test_obj.py
+checkpoints/

--- a/pbr_model/model.py
+++ b/pbr_model/model.py
@@ -1,0 +1,266 @@
+"""Sketch + prompt → PBR maps / render model scaffold (issue #20).
+
+A small U-Net-style encoder/decoder with text injection at the bottleneck.
+Two variants matching the data loader (#19):
+
+- **Variant A** (primary): three output heads
+    - ``albedo``       — 3-channel image (B, 3, 512, 512) in [0, 1]
+    - ``roughness``    — 1-channel image (B, 1, 512, 512) in [0, 1]
+    - ``lighting_sh``  — 9 floats        (B, 9), unconstrained
+
+- **Variant B** (ablation): one output head
+    - ``render``       — 3-channel image (B, 3, 512, 512) in [0, 1]
+
+Variant selectable via the ``variant`` arg, matching the data loader's flag.
+
+This file contains **architecture only** — no optimizer, no training loop, no
+loss. Per #20's spec: "Forward pass runs on a fake batch of size 2 without
+crashing; output shapes match expected targets."
+
+Text encoder note: the included ``TextEncoder`` is a *stub* (hash → embedding
+lookup → linear projection). Swap with CLIP / HuggingFace transformers in
+real training. The architecture upstream of the text encoder doesn't change.
+
+CLI smoke test::
+
+    python -m pbr_model.model --variant a --batch-size 2
+    python -m pbr_model.model --variant b --batch-size 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Literal
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+# ---------------------------------------------------------------------------
+# U-Net building blocks
+# ---------------------------------------------------------------------------
+
+
+class DoubleConv(nn.Module):
+    """Conv → BN → ReLU twice. The basic U-Net residual unit."""
+
+    def __init__(self, in_c: int, out_c: int) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Conv2d(in_c, out_c, kernel_size=3, padding=1),
+            nn.BatchNorm2d(out_c),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(out_c, out_c, kernel_size=3, padding=1),
+            nn.BatchNorm2d(out_c),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+class Down(nn.Module):
+    """MaxPool 2× downsample → DoubleConv."""
+
+    def __init__(self, in_c: int, out_c: int) -> None:
+        super().__init__()
+        self.net = nn.Sequential(nn.MaxPool2d(2), DoubleConv(in_c, out_c))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+class Up(nn.Module):
+    """Transposed-conv 2× upsample, concat skip, DoubleConv."""
+
+    def __init__(self, in_c: int, skip_c: int, out_c: int) -> None:
+        super().__init__()
+        self.up = nn.ConvTranspose2d(in_c, in_c // 2, kernel_size=2, stride=2)
+        self.conv = DoubleConv(in_c // 2 + skip_c, out_c)
+
+    def forward(self, x: torch.Tensor, skip: torch.Tensor) -> torch.Tensor:
+        x = self.up(x)
+        # Pad if skip's spatial dims are slightly different (handles odd input sizes).
+        if x.shape[-2:] != skip.shape[-2:]:
+            x = F.interpolate(x, size=skip.shape[-2:], mode="bilinear", align_corners=False)
+        x = torch.cat([x, skip], dim=1)
+        return self.conv(x)
+
+
+# ---------------------------------------------------------------------------
+# Text encoder (stub — replace with CLIP / HuggingFace in real training)
+# ---------------------------------------------------------------------------
+
+
+class TextEncoder(nn.Module):
+    """Toy text encoder: hash each prompt → vocab id → learned embedding → linear.
+
+    Deterministic enough for scaffold smoke tests; *not* what real training will use.
+    Swap with a real text encoder (CLIP, T5, frozen BERT, etc.) — only requirement
+    is output shape ``(B, embed_dim)``.
+    """
+
+    def __init__(self, embed_dim: int = 128, vocab_size: int = 10_000) -> None:
+        super().__init__()
+        self.vocab_size = vocab_size
+        self.emb = nn.Embedding(vocab_size, embed_dim)
+        self.proj = nn.Linear(embed_dim, embed_dim)
+
+    def forward(self, prompts: list[str]) -> torch.Tensor:
+        device = next(self.parameters()).device
+        # 4-token toy hash so two different prompts produce different ids.
+        ids = torch.tensor(
+            [
+                [hash(p[i::4]) % self.vocab_size for i in range(4)]
+                for p in prompts
+            ],
+            device=device,
+            dtype=torch.long,
+        )
+        embs = self.emb(ids).mean(dim=1)  # (B, D)
+        return F.relu(self.proj(embs))
+
+
+# ---------------------------------------------------------------------------
+# Full model
+# ---------------------------------------------------------------------------
+
+
+class PBRModel(nn.Module):
+    """Sketch + prompt → PBR maps (Variant A) or combined render (Variant B).
+
+    Args:
+        variant: 'a' or 'b' — selects which output heads are built.
+        base_channels: U-Net width at the top resolution (32 in the scaffold).
+        text_dim: dimensionality of the text encoder's output features.
+    """
+
+    def __init__(
+        self,
+        variant: Literal["a", "b"] = "a",
+        base_channels: int = 32,
+        text_dim: int = 128,
+    ) -> None:
+        super().__init__()
+        if variant not in ("a", "b"):
+            raise ValueError(f"variant must be 'a' or 'b', got {variant!r}")
+        self.variant: Literal["a", "b"] = variant
+
+        c = base_channels
+        # --- Encoder ---
+        self.in_conv = DoubleConv(3, c)        # input: sketch (B, 3, H, W)
+        self.down1 = Down(c, c * 2)
+        self.down2 = Down(c * 2, c * 4)
+        self.down3 = Down(c * 4, c * 8)
+        self.down4 = Down(c * 8, c * 16)       # bottleneck (B, 16c, H/16, W/16)
+
+        # --- Text injection at the bottleneck ---
+        self.text_enc = TextEncoder(embed_dim=text_dim)
+        self.text_proj = nn.Linear(text_dim, c * 16)
+
+        # --- Decoder ---
+        self.up1 = Up(c * 16, c * 8, c * 8)
+        self.up2 = Up(c * 8, c * 4, c * 4)
+        self.up3 = Up(c * 4, c * 2, c * 2)
+        self.up4 = Up(c * 2, c, c)
+
+        # --- Heads ---
+        if variant == "a":
+            self.head_albedo = nn.Conv2d(c, 3, kernel_size=1)
+            self.head_roughness = nn.Conv2d(c, 1, kernel_size=1)
+            self.head_lighting = nn.Sequential(
+                nn.AdaptiveAvgPool2d(1),
+                nn.Flatten(),
+                nn.Linear(c * 16, 64),
+                nn.ReLU(inplace=True),
+                nn.Linear(64, 9),
+            )
+        else:  # variant b
+            self.head_render = nn.Conv2d(c, 3, kernel_size=1)
+
+    def forward(self, sketch: torch.Tensor, prompt: list[str]) -> dict:
+        if sketch.dim() != 4 or sketch.size(1) != 3:
+            raise ValueError(f"sketch must be (B, 3, H, W), got {tuple(sketch.shape)}")
+        if not isinstance(prompt, list) or len(prompt) != sketch.size(0):
+            raise ValueError(
+                f"prompt must be list[str] of len {sketch.size(0)} (matching batch), "
+                f"got {type(prompt).__name__} len={len(prompt) if isinstance(prompt, list) else 'n/a'}"
+            )
+
+        # Encoder
+        x0 = self.in_conv(sketch)              # (B,   c, H,    W)
+        x1 = self.down1(x0)                    # (B,  2c, H/2,  W/2)
+        x2 = self.down2(x1)                    # (B,  4c, H/4,  W/4)
+        x3 = self.down3(x2)                    # (B,  8c, H/8,  W/8)
+        x4 = self.down4(x3)                    # (B, 16c, H/16, W/16)  — bottleneck
+
+        # Inject text at bottleneck (per-sample channel-wise bias)
+        text_feat = self.text_enc(prompt)      # (B, text_dim)
+        text_feat = self.text_proj(text_feat)  # (B, 16c)
+        x4 = x4 + text_feat[:, :, None, None]  # broadcast across spatial
+
+        # Decoder with skips
+        d3 = self.up1(x4, x3)                  # (B, 8c, H/8, W/8)
+        d2 = self.up2(d3, x2)                  # (B, 4c, H/4, W/4)
+        d1 = self.up3(d2, x1)                  # (B, 2c, H/2, W/2)
+        d0 = self.up4(d1, x0)                  # (B,  c, H,   W)
+
+        # Heads
+        out: dict = {}
+        if self.variant == "a":
+            out["albedo"] = torch.sigmoid(self.head_albedo(d0))      # (B, 3, H, W)
+            out["roughness"] = torch.sigmoid(self.head_roughness(d0))  # (B, 1, H, W)
+            out["lighting_sh"] = self.head_lighting(x4)              # (B, 9)
+        else:
+            out["render"] = torch.sigmoid(self.head_render(d0))      # (B, 3, H, W)
+        return out
+
+
+def make_model(
+    variant: Literal["a", "b"] = "a",
+    base_channels: int = 32,
+    text_dim: int = 128,
+) -> PBRModel:
+    """Factory for ``PBRModel``. Mirrors ``pbr_model.dataset.make_dataloader``."""
+    return PBRModel(variant=variant, base_channels=base_channels, text_dim=text_dim)
+
+
+# ---------------------------------------------------------------------------
+# Smoke test
+# ---------------------------------------------------------------------------
+
+
+def _smoke_test(args: argparse.Namespace) -> None:
+    torch.manual_seed(0)
+    model = make_model(variant=args.variant, base_channels=args.base_channels)
+    n_params = sum(p.numel() for p in model.parameters())
+    print(f"PBRModel(variant={args.variant!r}, base_channels={args.base_channels}) | {n_params:,} params")
+
+    sketch = torch.randn(args.batch_size, 3, args.size, args.size)
+    prompts = [f"cloth sample {i}" for i in range(args.batch_size)]
+
+    model.eval()
+    with torch.no_grad():
+        outputs = model(sketch, prompts)
+
+    print(f"forward(sketch={tuple(sketch.shape)}, prompt=list[str]×{args.batch_size}):")
+    for k, v in outputs.items():
+        print(f"  {k:>12}: {tuple(v.shape)} {v.dtype}  range=[{v.min().item():.3f}, {v.max().item():.3f}]")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--variant", choices=["a", "b"], default="a")
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--size", type=int, default=512, help="square input H=W")
+    parser.add_argument("--base-channels", type=int, default=32)
+    args = parser.parse_args()
+    _smoke_test(args)
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    main()

--- a/pbr_model/model.py
+++ b/pbr_model/model.py
@@ -99,13 +99,14 @@ class TextEncoder(nn.Module):
     """Toy text encoder: hash each prompt → vocab id → learned embedding → linear.
 
     Deterministic enough for scaffold smoke tests; *not* what real training will use.
-    Swap with a real text encoder (CLIP, T5, frozen BERT, etc.) — only requirement
-    is output shape ``(B, embed_dim)``.
+    Swap with ``CLIPTextEncoder`` (or another real encoder) for real training —
+    only requirement is output shape ``(B, embed_dim)``.
     """
 
     def __init__(self, embed_dim: int = 128, vocab_size: int = 10_000) -> None:
         super().__init__()
         self.vocab_size = vocab_size
+        self.embed_dim = embed_dim
         self.emb = nn.Embedding(vocab_size, embed_dim)
         self.proj = nn.Linear(embed_dim, embed_dim)
 
@@ -122,6 +123,59 @@ class TextEncoder(nn.Module):
         )
         embs = self.emb(ids).mean(dim=1)  # (B, D)
         return F.relu(self.proj(embs))
+
+
+class CLIPTextEncoder(nn.Module):
+    """Frozen CLIP text encoder for real training (issue #32).
+
+    Wraps ``transformers.CLIPTextModel`` + ``CLIPTokenizer``. Pretrained on
+    400M (image, text) pairs, so prompts like "houndstooth pattern", "silk",
+    "draped" already carry visually-grounded meaning before our network ever
+    starts training.
+
+    - First call downloads ~250 MB to ``~/.cache/huggingface/`` (offline thereafter).
+    - Frozen — no gradient flows into CLIP. It's a fixed feature extractor.
+    - Output shape: ``(B, embed_dim)`` where embed_dim = 512 for ViT-B/32.
+
+    Drop-in replacement for ``TextEncoder``: same forward signature ``(list[str]) → (B, D)``.
+    """
+
+    def __init__(self, model_name: str = "openai/clip-vit-base-patch32") -> None:
+        super().__init__()
+        try:
+            from transformers import CLIPTextModel, CLIPTokenizer
+        except ImportError as e:
+            raise ImportError(
+                "CLIPTextEncoder requires the `transformers` package. "
+                "Install with: python3 -m pip install transformers"
+            ) from e
+        self.tokenizer = CLIPTokenizer.from_pretrained(model_name)
+        self.text_model = CLIPTextModel.from_pretrained(model_name)
+        # Freeze: no gradient through CLIP at training time.
+        for p in self.text_model.parameters():
+            p.requires_grad = False
+        self.text_model.eval()
+        self.embed_dim = self.text_model.config.hidden_size  # 512 for ViT-B/32
+
+    def forward(self, prompts: list[str]) -> torch.Tensor:
+        device = next(self.text_model.parameters()).device
+        tokens = self.tokenizer(
+            prompts,
+            padding=True,
+            truncation=True,
+            max_length=77,  # CLIP's standard context length
+            return_tensors="pt",
+        ).to(device)
+        with torch.no_grad():  # belt-and-suspenders: requires_grad already False
+            out = self.text_model(**tokens)
+        # ``pooler_output`` is the EOT-token embedding — CLIP's standard sentence vector.
+        return out.pooler_output  # (B, embed_dim)
+
+    def train(self, mode: bool = True) -> "CLIPTextEncoder":
+        # Override: keep CLIP in eval mode regardless of parent module's train()/eval().
+        super().train(mode)
+        self.text_model.eval()
+        return self
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +197,8 @@ class PBRModel(nn.Module):
         variant: Literal["a", "b"] = "a",
         base_channels: int = 32,
         text_dim: int = 128,
+        use_clip: bool = False,
+        clip_model: str = "openai/clip-vit-base-patch32",
     ) -> None:
         super().__init__()
         if variant not in ("a", "b"):
@@ -158,7 +214,14 @@ class PBRModel(nn.Module):
         self.down4 = Down(c * 8, c * 16)       # bottleneck (B, 16c, H/16, W/16)
 
         # --- Text injection at the bottleneck ---
-        self.text_enc = TextEncoder(embed_dim=text_dim)
+        # use_clip=True: frozen CLIP text encoder (real training).
+        # use_clip=False: the toy stub encoder (scaffold smoke tests).
+        if use_clip:
+            self.text_enc = CLIPTextEncoder(model_name=clip_model)
+            text_dim = self.text_enc.embed_dim  # 512 for ViT-B/32
+        else:
+            self.text_enc = TextEncoder(embed_dim=text_dim)
+        self.use_clip = use_clip
         self.text_proj = nn.Linear(text_dim, c * 16)
 
         # --- Decoder ---
@@ -223,9 +286,22 @@ def make_model(
     variant: Literal["a", "b"] = "a",
     base_channels: int = 32,
     text_dim: int = 128,
+    use_clip: bool = False,
+    clip_model: str = "openai/clip-vit-base-patch32",
 ) -> PBRModel:
-    """Factory for ``PBRModel``. Mirrors ``pbr_model.dataset.make_dataloader``."""
-    return PBRModel(variant=variant, base_channels=base_channels, text_dim=text_dim)
+    """Factory for ``PBRModel``. Mirrors ``pbr_model.dataset.make_dataloader``.
+
+    ``use_clip=True`` swaps the toy stub text encoder for a frozen CLIP encoder.
+    Default is ``False`` so scaffold smoke tests stay fast and don't require
+    the ~250 MB CLIP download.
+    """
+    return PBRModel(
+        variant=variant,
+        base_channels=base_channels,
+        text_dim=text_dim,
+        use_clip=use_clip,
+        clip_model=clip_model,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -235,9 +311,18 @@ def make_model(
 
 def _smoke_test(args: argparse.Namespace) -> None:
     torch.manual_seed(0)
-    model = make_model(variant=args.variant, base_channels=args.base_channels)
+    model = make_model(
+        variant=args.variant,
+        base_channels=args.base_channels,
+        use_clip=args.use_clip,
+    )
     n_params = sum(p.numel() for p in model.parameters())
-    print(f"PBRModel(variant={args.variant!r}, base_channels={args.base_channels}) | {n_params:,} params")
+    n_train = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    text_kind = "CLIP" if args.use_clip else "stub"
+    print(
+        f"PBRModel(variant={args.variant!r}, base_channels={args.base_channels}, "
+        f"text={text_kind}) | {n_params:,} params total, {n_train:,} trainable"
+    )
 
     sketch = torch.randn(args.batch_size, 3, args.size, args.size)
     prompts = [f"cloth sample {i}" for i in range(args.batch_size)]
@@ -257,6 +342,10 @@ def main() -> None:
     parser.add_argument("--batch-size", type=int, default=2)
     parser.add_argument("--size", type=int, default=512, help="square input H=W")
     parser.add_argument("--base-channels", type=int, default=32)
+    parser.add_argument(
+        "--use-clip", action="store_true",
+        help="Use frozen CLIP text encoder instead of the toy stub. Downloads ~250 MB on first call.",
+    )
     args = parser.parse_args()
     _smoke_test(args)
 

--- a/pbr_model/train.py
+++ b/pbr_model/train.py
@@ -84,6 +84,7 @@ def train(
     steps: int = 10,
     lr: float = 1e-3,
     base_channels: int = 16,
+    use_clip: bool = False,
     lambda_roughness: float = 1.0,
     lambda_lighting: float = 0.1,
     checkpoint_path: str | Path = "checkpoints/scaffold.pt",
@@ -92,12 +93,16 @@ def train(
 ) -> dict:
     """Run a tiny training loop. Returns a dict with first/last loss + checkpoint path."""
     if verbose:
-        print(f"=== training scaffold | variant={variant} | bs={batch_size} | steps={steps} | device={device} ===")
+        text_kind = "CLIP" if use_clip else "stub"
+        print(
+            f"=== training scaffold | variant={variant} | bs={batch_size} | steps={steps} "
+            f"| text={text_kind} | device={device} ==="
+        )
 
     loader = make_dataloader(
         metadata_path=metadata_path, variant=variant, batch_size=batch_size, shuffle=True,
     )
-    model = make_model(variant=variant, base_channels=base_channels).to(device)
+    model = make_model(variant=variant, base_channels=base_channels, use_clip=use_clip).to(device)
     model.train()
     optimizer = torch.optim.Adam(model.parameters(), lr=lr)
 
@@ -178,6 +183,10 @@ def main() -> None:
     parser.add_argument("--steps", type=int, default=10)
     parser.add_argument("--lr", type=float, default=1e-3)
     parser.add_argument("--base-channels", type=int, default=16)
+    parser.add_argument(
+        "--use-clip", action="store_true",
+        help="Use frozen CLIP text encoder instead of the stub (real-training quality, ~250 MB download).",
+    )
     parser.add_argument("--lambda-roughness", type=float, default=1.0)
     parser.add_argument("--lambda-lighting", type=float, default=0.1)
     parser.add_argument("--checkpoint", default="checkpoints/scaffold.pt")
@@ -191,6 +200,7 @@ def main() -> None:
         steps=args.steps,
         lr=args.lr,
         base_channels=args.base_channels,
+        use_clip=args.use_clip,
         lambda_roughness=args.lambda_roughness,
         lambda_lighting=args.lambda_lighting,
         checkpoint_path=args.checkpoint,

--- a/pbr_model/train.py
+++ b/pbr_model/train.py
@@ -1,0 +1,203 @@
+"""Training loop scaffold (issue #21).
+
+Standard PyTorch training boilerplate connecting the data loader (#19) and the
+model (#20). This is a *scaffold* — it proves the wiring is correct and is
+intentionally tuned for laptop CPU smoke-testing, not for real training runs.
+
+**Variant A loss:**  ``L_albedo + λ₁·L_roughness + λ₂·L_lighting``  (all MSE)
+
+**Variant B loss:**  ``L_render``  (MSE)
+
+Acceptance criteria from #21:
+
+- Runs end-to-end on a tiny batch (2 samples, CPU) without errors
+- Loss decreases over 10 steps (proves backward pass connects)
+- Saves a checkpoint ``.pt`` file
+- Both variants runnable via ``--variant`` flag
+
+CLI smoke test::
+
+    python -m pbr_model.train --variant b --batch-size 2 --steps 10
+    python -m pbr_model.train --variant a --batch-size 2 --steps 10  # needs lighting_sh
+
+NOT chasing accuracy — just proves the loop works.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Literal
+
+import torch
+import torch.nn.functional as F
+
+from pbr_model.dataset import make_dataloader
+from pbr_model.model import make_model
+
+
+# ---------------------------------------------------------------------------
+# Loss
+# ---------------------------------------------------------------------------
+
+
+def compute_loss(
+    outputs: dict,
+    batch: dict,
+    variant: Literal["a", "b"],
+    lambda_roughness: float = 1.0,
+    lambda_lighting: float = 0.1,
+) -> tuple[torch.Tensor, dict]:
+    """Variant A: weighted-MSE on albedo + roughness + lighting_sh.
+    Variant B: MSE on the combined render.
+
+    Returns (total_loss, components_dict) so we can log per-term scalars.
+    """
+    if variant == "a":
+        l_albedo = F.mse_loss(outputs["albedo"], batch["albedo"])
+        l_rough = F.mse_loss(outputs["roughness"], batch["roughness"])
+        l_light = F.mse_loss(outputs["lighting_sh"], batch["lighting_sh"])
+        total = l_albedo + lambda_roughness * l_rough + lambda_lighting * l_light
+        return total, {
+            "L_albedo": l_albedo.item(),
+            "L_roughness": l_rough.item(),
+            "L_lighting": l_light.item(),
+            "total": total.item(),
+        }
+    # variant b
+    l_render = F.mse_loss(outputs["render"], batch["render"])
+    return l_render, {"L_render": l_render.item(), "total": l_render.item()}
+
+
+# ---------------------------------------------------------------------------
+# Training loop
+# ---------------------------------------------------------------------------
+
+
+def train(
+    metadata_path: str | Path = "dataset/metadata.jsonl",
+    variant: Literal["a", "b"] = "b",
+    batch_size: int = 2,
+    steps: int = 10,
+    lr: float = 1e-3,
+    base_channels: int = 16,
+    lambda_roughness: float = 1.0,
+    lambda_lighting: float = 0.1,
+    checkpoint_path: str | Path = "checkpoints/scaffold.pt",
+    device: str = "cpu",
+    verbose: bool = True,
+) -> dict:
+    """Run a tiny training loop. Returns a dict with first/last loss + checkpoint path."""
+    if verbose:
+        print(f"=== training scaffold | variant={variant} | bs={batch_size} | steps={steps} | device={device} ===")
+
+    loader = make_dataloader(
+        metadata_path=metadata_path, variant=variant, batch_size=batch_size, shuffle=True,
+    )
+    model = make_model(variant=variant, base_channels=base_channels).to(device)
+    model.train()
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+
+    losses: list[float] = []
+    data_iter = iter(loader)
+
+    t0 = time.time()
+    for step in range(1, steps + 1):
+        try:
+            batch = next(data_iter)
+        except StopIteration:
+            # Single epoch may not cover ``steps`` iterations on tiny datasets — restart.
+            data_iter = iter(loader)
+            batch = next(data_iter)
+
+        # Move tensors to device; leave list[str] (prompt) on CPU.
+        batch = {k: (v.to(device) if torch.is_tensor(v) else v) for k, v in batch.items()}
+
+        optimizer.zero_grad()
+        outputs = model(batch["sketch"], batch["prompt"])
+        loss, components = compute_loss(
+            outputs, batch, variant=variant,
+            lambda_roughness=lambda_roughness, lambda_lighting=lambda_lighting,
+        )
+        loss.backward()
+        optimizer.step()
+
+        losses.append(loss.item())
+        if verbose:
+            comp_str = "  ".join(f"{k}={v:.4f}" for k, v in components.items() if k != "total")
+            print(f"  step {step:>3}/{steps} | loss = {loss.item():.4f}  {comp_str}")
+
+    elapsed = time.time() - t0
+
+    # Save checkpoint (state_dict + a few key settings).
+    checkpoint_path = Path(checkpoint_path)
+    checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(
+        {
+            "model_state_dict": model.state_dict(),
+            "optimizer_state_dict": optimizer.state_dict(),
+            "variant": variant,
+            "base_channels": base_channels,
+            "step": steps,
+            "first_loss": losses[0],
+            "last_loss": losses[-1],
+        },
+        checkpoint_path,
+    )
+    if verbose:
+        print(f"\ncheckpoint → {checkpoint_path}  (size: {checkpoint_path.stat().st_size / 1024:.1f} KB)")
+        print(f"first loss: {losses[0]:.4f} | last loss: {losses[-1]:.4f} | elapsed: {elapsed:.1f}s")
+        if losses[-1] < losses[0]:
+            print("✓ loss decreased — backward pass is connected end-to-end.")
+        else:
+            print("⚠ loss did not decrease over the run; may need more steps or a higher LR.")
+
+    return {
+        "first_loss": losses[0],
+        "last_loss": losses[-1],
+        "losses": losses,
+        "checkpoint_path": str(checkpoint_path),
+        "elapsed_s": elapsed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--metadata", default="dataset/metadata.jsonl")
+    parser.add_argument("--variant", choices=["a", "b"], default="b",
+                        help="A: separated PBR maps + lighting; B: combined render. Default B (no lighting_sh prereq).")
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--steps", type=int, default=10)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--base-channels", type=int, default=16)
+    parser.add_argument("--lambda-roughness", type=float, default=1.0)
+    parser.add_argument("--lambda-lighting", type=float, default=0.1)
+    parser.add_argument("--checkpoint", default="checkpoints/scaffold.pt")
+    parser.add_argument("--device", default="cpu", help="cpu | cuda | mps")
+    args = parser.parse_args()
+
+    train(
+        metadata_path=args.metadata,
+        variant=args.variant,
+        batch_size=args.batch_size,
+        steps=args.steps,
+        lr=args.lr,
+        base_channels=args.base_channels,
+        lambda_roughness=args.lambda_roughness,
+        lambda_lighting=args.lambda_lighting,
+        checkpoint_path=args.checkpoint,
+        device=args.device,
+    )
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    main()


### PR DESCRIPTION
## What this PR is

When the stacked PRs #30 / #31 / #33 were merged, they each landed in their **parent feature branch** instead of cascading to main:

- #30 (model scaffold) merged → ``feature/data-loader`` (not main)
- #31 (training scaffold) merged → ``feature/model-scaffold`` (not main)
- #33 (CLIP encoder) merged → ``feature/training-scaffold`` (not main)

PR #29 (data loader) merged into main *before* #30 landed in its stack, so main only got the data loader. The model + training + CLIP code never made the trip to main.

This PR brings the 3 missing commits to main:

```
82bc0df  feat(#32): CLIPTextEncoder — frozen pretrained text encoder
07846da  feat(#21): training loop scaffold (pbr_model/train.py)
51e190a  feat(#20): model scaffold (pbr_model/model.py)
```

After merge, ``pbr_model/`` will have the full set: ``dataset.py`` + ``model.py`` + ``train.py`` + ``preprocess_lighting_sh.py`` + ``__init__.py``, with CLIP support via ``use_clip=True`` flag.

## Already verified

- Each commit was independently smoke-tested on its own PR (#30, #31, #33)
- Forward+backward passes work, checkpoints save, CLIP frozen correctly
- See those PRs for detailed test outputs

## Closes

- #20 (model scaffold) — already linked to #30, but #30 didn't reach main
- #21 (training scaffold) — already linked to #31
- #32 (CLIP encoder) — already linked to #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)