### PR TITLE
docs: overlay Qwen + CLIP on the three pipeline diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ Runs once, offline.
                              │
                              ▼
 ┌──────────────────────────────────────────────────────────┐
+│  Qwen2-VL-7B  (FROZEN, GPU, DF3D samples only)           │
+│  reads render.png, rewrites metadata.json["text"] +      │
+│  prompt.txt with a per-sample visual caption             │
+│  (color, pattern, fabric, lighting, view).               │
+│  Manual + procedural samples are passed through.         │
+└────────────────────────────┬─────────────────────────────┘
+                             │
+                             ▼
+   prompt.txt (enriched on DF3D)  metadata.json["text"] (same)
+                             │
+                             ▼
+┌──────────────────────────────────────────────────────────┐
 │  Stage 2 — Sketch Extraction                             │
 └────────────────────────────┬─────────────────────────────┘
                              │
@@ -62,12 +74,22 @@ Runs once, offline.
                      │                                       │
                      ▼                                       ▼
    ┌──────────────────────────────────┐    ┌──────────────────────────────────┐
-   │          Neural Network          │    │          Neural Network          │
-   └──────┬─────────┬─────────┬───────┘    └────────────────┬─────────────────┘
-          │         │         │                             │
-          ▼         ▼         ▼                             ▼
-        albedo  roughness  lighting                   render (2D .png)
-                          (9 floats)
+   │       Neural Network             │    │       Neural Network             │
+   │                                  │    │                                  │
+   │ prompt ──►┌──────────┐           │    │ prompt ──►┌──────────┐           │
+   │           │  CLIP    │           │    │           │  CLIP    │           │
+   │           │ (FROZEN) │           │    │           │ (FROZEN) │           │
+   │           └────┬─────┘           │    │           └────┬─────┘           │
+   │                │ (B, 512)        │    │                │ (B, 512)        │
+   │                ▼                 │    │                ▼                 │
+   │ sketch ──►┌──────────┐           │    │ sketch ──►┌──────────┐           │
+   │           │  U-Net   │           │    │           │  U-Net   │           │
+   │           │(TRAINABLE)           │    │           │(TRAINABLE)           │
+   │           └─┬───┬──┬─┘           │    │           └─────┬────┘           │
+   └─────────────┼───┼──┼─────────────┘    └─────────────────┼────────────────┘
+                 ▼   ▼  ▼                                     ▼
+              albedo roughness lighting                     render
+                            (9 floats)
 
    Loss:  L_albedo + λ₁·L_roughness        Loss:  L_render  (MSE)
                    + λ₂·L_lighting  (MSE)
@@ -91,31 +113,46 @@ End-user pipeline.
                 │                                    │
         ┌───────┴───────┐                   ┌────────┴────────┐
         ▼               ▼                   ▼                 ▼
-   ┌──────────┐  ┌──────────────┐    ┌────────────┐  ┌─────────────────┐
-   │  Gemini  │  │ Trained PBR  │    │  In-house  │  │   Trained PBR   │
-   │   API    │  │    Model     │    │  sketch →  │  │      Model      │
-   └────┬─────┘  └──────┬───────┘    │    mesh    │  └────────┬────────┘
-        │               │            │  (FUTURE)  │           │
-        ▼               ▼            └─────┬──────┘           ▼
-    2D image     albedo + roughness        │           albedo + roughness
-                        + lighting                             + lighting
-        │               │                  ▼                  │
-        ▼               │                mesh                 │
-   ┌──────────┐         │                  │                  │
-   │ Trellis  │         │                  └─────────┬────────┘
-   └────┬─────┘         │                            ▼
-        │               │                   ┌────────────────┐
-        ▼               │                   │   Compositor   │
-       mesh             │                   └────────┬───────┘
-        │               │                            │
-        └───────┬───────┘                            ▼
-                ▼                                  Scene
+                ┌─────────────────┐                    ┌─────────────────┐
+   ┌──────────┐ │ Trained PBR     │  ┌────────────┐    │ Trained PBR     │
+   │  Gemini  │ │   Model         │  │  In-house  │    │   Model         │
+   │   API    │ │ ┌────────┐      │  │  sketch →  │    │ ┌────────┐      │
+   │ (FROZEN) │ │ │ CLIP   │◄─prompt│  │    mesh    │    │ │ CLIP   │◄─prompt
+   └────┬─────┘ │ │(FROZEN)│      │  │  (FUTURE)  │    │ │(FROZEN)│      │
+        │       │ └───┬────┘      │  └─────┬──────┘    │ └───┬────┘      │
+        │       │     │ (B,512)   │        │           │     │ (B,512)   │
+        │       │ ┌───┴─────┐     │        │           │ ┌───┴─────┐     │
+        │       │ │  U-Net  │◄──sketch     │           │ │  U-Net  │◄──sketch
+        │       │ │(trained │     │        │           │ │(trained │     │
+        │       │ │ weights)│     │        │           │ │ weights)│     │
+        │       │ └─┬───┬─┬─┘     │        │           │ └─┬───┬─┬─┘     │
+        │       └───┼───┼─┼───────┘        │           └───┼───┼─┼───────┘
+        ▼           ▼   ▼ ▼                ▼               ▼   ▼ ▼
+    2D image    albedo+roughness          mesh        albedo+roughness
+                       +lighting           │                   +lighting
+        │               │                  │                       │
+        ▼               │                  └─────────┬─────────────┘
+   ┌──────────┐         │                            ▼
+   │ Trellis  │         │                   ┌────────────────┐
+   └────┬─────┘         │                   │   Compositor   │
+        │               │                   └────────┬───────┘
+        ▼               │                            │
+      mesh              │                            ▼
+        │               │                          Scene
+        └───────┬───────┘
+                ▼
         ┌────────────────┐
         │   Compositor   │
         └────────┬───────┘
                  │
                  ▼
                Scene
+
+Notes:
+- CLIP is the **same frozen weights** as during training (Pipeline 2). The user's
+  free-form prompt goes through the same encoder the model learned to read.
+- Qwen does NOT run at inference — it was a training-data preprocessing step.
+  Once the model is trained, only CLIP + U-Net are needed.
 ```
 
 **Comparison**

--- a/README.md
+++ b/README.md
@@ -18,38 +18,43 @@ Runs once, offline.
                     output_meshes/*.obj
                              │
                              ▼
-┌──────────────────────────────────────────────────────────┐
-│  Stage 1 — PBR Rendering (Mitsuba 3)                     │
-│  scene = mesh + material + lighting + camera             │
-└────────────────────────────┬─────────────────────────────┘
-                             │
-                             ▼
-       all outputs below come from one render of the scene
-                             │
-                             ▼
-   render.png  albedo.png  roughness.png  normal.png  mask.png
-   texture.png  depth.npy  normals.npy
-   prompt.txt  metadata.json
-                             │
-                             ▼
-┌──────────────────────────────────────────────────────────┐
-│  Qwen2-VL-7B  (FROZEN, GPU, DF3D samples only)           │
-│  reads render.png, rewrites metadata.json["text"] +      │
-│  prompt.txt with a per-sample visual caption             │
-│  (color, pattern, fabric, lighting, view).               │
-│  Manual + procedural samples are passed through.         │
-└────────────────────────────┬─────────────────────────────┘
-                             │
-                             ▼
-   prompt.txt (enriched on DF3D)  metadata.json["text"] (same)
-                             │
-                             ▼
-┌──────────────────────────────────────────────────────────┐
-│  Stage 2 — Sketch Extraction                             │
-└────────────────────────────┬─────────────────────────────┘
-                             │
-                             ▼
-                        sketch.png
+┌──────────────────────────────────────────────────────────────────────┐
+│  Stage 1 — PBR Rendering (Mitsuba 3, per sample)                     │
+│  scene = mesh + material/texture + lighting + camera                 │
+│  DF3D: bundled <id>_tex.png used as albedo (no procedural pattern)   │
+└────────────────────────────────┬─────────────────────────────────────┘
+                                 │
+                                 ▼
+                    per sample, all in one folder:
+       render.png  albedo.png  roughness.png  normal.png  mask.png
+       texture.png  depth.npy  normals.npy  prompt.txt  metadata.json
+                                 │
+                  ┌──────────────┴──────────────┐
+                  │                             │
+       (DF3D samples only)               (all samples)
+                  │                             │
+                  ▼                             ▼
+   ┌──────────────────────────────┐   ┌─────────────────────────────────┐
+   │  Qwen2-VL-7B  (FROZEN, GPU)  │   │  Stage 2 — Sketch Extraction    │
+   │                              │   │  (Neçirvan's CV pipeline)       │
+   │  input:  render.png          │   │                                 │
+   │  output: rich visual caption │   │  input:   render.png + masks +  │
+   │          (color, pattern,    │   │           normals + albedo      │
+   │           fabric, lighting,  │   │  output:  sketch.png            │
+   │           view)              │   │                                 │
+   │  rewrites in place:          │   │                                 │
+   │    prompt.txt                │   │                                 │
+   │    metadata.json["text"]     │   │                                 │
+   └──────────────────────────────┘   └─────────────────────────────────┘
+                  │                             │
+                  ▼                             ▼
+         (no new files —                     sketch.png
+          existing prompt.txt
+          and metadata are
+          updated in place)
+
+   Both branches run on the same per-sample folder. Qwen and Stage 2 are
+   independent — neither depends on the other's output.
 
    All written into  dataset/<bucket>/<mesh>/<material>_<pattern>/view_<n>/sample_<NNNN>/
                           ↑ bucket = manual / df3d / procedural (auto-derived from mesh source)
@@ -67,32 +72,38 @@ Runs once, offline.
 ### Pipeline 2 — Training
 
 ```
-   VARIANT A — Separated PBR maps          VARIANT B — Combined render
-   (primary)                               (ablation)
+   VARIANT A — Separated PBR maps (primary)         VARIANT B — Combined render (ablation)
 
-          sketch.png + prompt.txt                 sketch.png + prompt.txt
-                     │                                       │
-                     ▼                                       ▼
-   ┌──────────────────────────────────┐    ┌──────────────────────────────────┐
-   │       Neural Network             │    │       Neural Network             │
-   │                                  │    │                                  │
-   │ prompt ──►┌──────────┐           │    │ prompt ──►┌──────────┐           │
-   │           │  CLIP    │           │    │           │  CLIP    │           │
-   │           │ (FROZEN) │           │    │           │ (FROZEN) │           │
-   │           └────┬─────┘           │    │           └────┬─────┘           │
-   │                │ (B, 512)        │    │                │ (B, 512)        │
-   │                ▼                 │    │                ▼                 │
-   │ sketch ──►┌──────────┐           │    │ sketch ──►┌──────────┐           │
-   │           │  U-Net   │           │    │           │  U-Net   │           │
-   │           │(TRAINABLE)           │    │           │(TRAINABLE)           │
-   │           └─┬───┬──┬─┘           │    │           └─────┬────┘           │
-   └─────────────┼───┼──┼─────────────┘    └─────────────────┼────────────────┘
-                 ▼   ▼  ▼                                     ▼
-              albedo roughness lighting                     render
-                            (9 floats)
+   sketch.png       prompt.txt                      sketch.png       prompt.txt
+   (B,3,512,512)    list[str] len=B                 (B,3,512,512)    list[str] len=B
+        │                 │                                │                 │
+        │                 ▼                                │                 ▼
+        │          ┌─────────────┐                         │          ┌─────────────┐
+        │          │    CLIP     │                         │          │    CLIP     │
+        │          │  (FROZEN)   │                         │          │  (FROZEN)   │
+        │          └──────┬──────┘                         │          └──────┬──────┘
+        │                 │                                │                 │
+        │            text feat (B, 512)                    │            text feat (B, 512)
+        │                 │                                │                 │
+        ▼                 ▼                                ▼                 ▼
+   ┌──────────────────────────────────┐              ┌──────────────────────────────────┐
+   │             U-Net                │              │             U-Net                │
+   │  takes sketch (image input) +    │              │  takes sketch (image input) +    │
+   │  text feat (channel-wise bias    │              │  text feat (channel-wise bias    │
+   │  at bottleneck)  →  predicts maps│              │  at bottleneck)  →  predicts img │
+   │           (TRAINABLE)            │              │           (TRAINABLE)            │
+   └─────┬─────────┬─────────┬────────┘              └─────────────────┬────────────────┘
+         │         │         │                                         │
+         ▼         ▼         ▼                                         ▼
+       albedo   roughness  lighting_sh                              render
+     (B,3,H,W) (B,1,H,W)  (B, 9 floats)                          (B,3,H,W)
 
-   Loss:  L_albedo + λ₁·L_roughness        Loss:  L_render  (MSE)
-                   + λ₂·L_lighting  (MSE)
+   Loss:  L_albedo + λ₁·L_roughness + λ₂·L_lighting     Loss:  L_render  (MSE)
+                            (all MSE)
+
+   Note: the sketch is an INPUT, never derived from prompt. CLIP only processes
+   the prompt. Both flow into the U-Net at different points (sketch as the image
+   input, text features added as channel-wise bias at the U-Net bottleneck).
 ```
 
 Variants share dataset, loader, and architecture. They differ only in output head and loss target.
@@ -103,57 +114,109 @@ Lighting prediction in Variant A captures Dr. Montazeri's point that sketch high
 
 ### Pipeline 3 — Inference
 
-End-user pipeline.
+End-user pipeline. Two variants — same Trained PBR Model in both, only the mesh source differs. The user's sketch is an INPUT to both the mesh-source path AND the U-Net inside the PBR Model. CLIP only processes the user's prompt; sketch is never derived from prompt.
+
+#### Variant 1 — Gemini + Trellis (external)
 
 ```
-   VARIANT 1 — Gemini + Trellis        VARIANT 2 — Fully in-house
-   (external)
-
-    user sketch + marks + prompt        user sketch + marks + prompt
-                │                                    │
-        ┌───────┴───────┐                   ┌────────┴────────┐
-        ▼               ▼                   ▼                 ▼
-                ┌─────────────────┐                    ┌─────────────────┐
-   ┌──────────┐ │ Trained PBR     │  ┌────────────┐    │ Trained PBR     │
-   │  Gemini  │ │   Model         │  │  In-house  │    │   Model         │
-   │   API    │ │ ┌────────┐      │  │  sketch →  │    │ ┌────────┐      │
-   │ (FROZEN) │ │ │ CLIP   │◄─prompt│  │    mesh    │    │ │ CLIP   │◄─prompt
-   └────┬─────┘ │ │(FROZEN)│      │  │  (FUTURE)  │    │ │(FROZEN)│      │
-        │       │ └───┬────┘      │  └─────┬──────┘    │ └───┬────┘      │
-        │       │     │ (B,512)   │        │           │     │ (B,512)   │
-        │       │ ┌───┴─────┐     │        │           │ ┌───┴─────┐     │
-        │       │ │  U-Net  │◄──sketch     │           │ │  U-Net  │◄──sketch
-        │       │ │(trained │     │        │           │ │(trained │     │
-        │       │ │ weights)│     │        │           │ │ weights)│     │
-        │       │ └─┬───┬─┬─┘     │        │           │ └─┬───┬─┬─┘     │
-        │       └───┼───┼─┼───────┘        │           └───┼───┼─┼───────┘
-        ▼           ▼   ▼ ▼                ▼               ▼   ▼ ▼
-    2D image    albedo+roughness          mesh        albedo+roughness
-                       +lighting           │                   +lighting
-        │               │                  │                       │
-        ▼               │                  └─────────┬─────────────┘
-   ┌──────────┐         │                            ▼
-   │ Trellis  │         │                   ┌────────────────┐
-   └────┬─────┘         │                   │   Compositor   │
-        │               │                   └────────┬───────┘
-        ▼               │                            │
-      mesh              │                            ▼
-        │               │                          Scene
-        └───────┬───────┘
-                ▼
-        ┌────────────────┐
-        │   Compositor   │
-        └────────┬───────┘
-                 │
-                 ▼
-               Scene
-
-Notes:
-- CLIP is the **same frozen weights** as during training (Pipeline 2). The user's
-  free-form prompt goes through the same encoder the model learned to read.
-- Qwen does NOT run at inference — it was a training-data preprocessing step.
-  Once the model is trained, only CLIP + U-Net are needed.
+                user sketch.png         user prompt
+                     │  │                    │
+                ┌────┘  └─────┐              │
+                │             │              │
+                ▼             │              │
+            ┌──────────┐      │              │
+            │  Gemini  │      │              │
+            │ (FROZEN) │      │              │
+            └────┬─────┘      │              │
+                 ▼            │              │
+             2D image         │              │
+                 │            │              │
+                 ▼            │              │
+            ┌──────────┐      │              │
+            │ Trellis  │      │              │
+            │ (FROZEN) │      │              │
+            └────┬─────┘      │              │
+                 │            │              ▼
+                 ▼            │       ┌─────────────┐
+                mesh          │       │    CLIP     │
+                 │            │       │  (FROZEN)   │
+                 │            │       └──────┬──────┘
+                 │            │              │ text feat (B, 512)
+                 │            ▼              ▼
+                 │       ┌──────────────────────────────┐
+                 │       │           U-Net              │
+                 │       │  takes sketch + text feat →  │
+                 │       │  predicts albedo, roughness, │
+                 │       │  lighting_sh                 │
+                 │       │      (trained weights;       │
+                 │       │       not updated at         │
+                 │       │       inference time)        │
+                 │       └─────┬─────────┬───────┬──────┘
+                 │             ▼         ▼       ▼
+                 │          albedo   roughness  lighting_sh
+                 │             │         │       │
+                 └───────────┐ │         │       │
+                             ▼ ▼         ▼       ▼
+                          ┌──────────────────────────┐
+                          │       Compositor         │
+                          │  combines mesh + maps    │
+                          │  + (predicted or user)   │
+                          │  lighting → final scene  │
+                          └────────────┬─────────────┘
+                                       ▼
+                                     Scene
 ```
+
+#### Variant 2 — Fully in-house
+
+```
+                user sketch.png         user prompt
+                     │  │                    │
+                ┌────┘  └─────┐              │
+                │             │              │
+                ▼             │              │
+         ┌────────────┐       │              │
+         │  In-house  │       │              │
+         │  sketch →  │       │              │
+         │   mesh     │       │              │
+         │  (FUTURE,  │       │              │
+         │  TRAINABLE)│       │              │
+         └─────┬──────┘       │              │
+               │              │              ▼
+               ▼              │       ┌─────────────┐
+              mesh            │       │    CLIP     │
+               │              │       │  (FROZEN)   │
+               │              │       └──────┬──────┘
+               │              │              │ text feat (B, 512)
+               │              ▼              ▼
+               │       ┌──────────────────────────────┐
+               │       │           U-Net              │
+               │       │  takes sketch + text feat →  │
+               │       │  predicts albedo, roughness, │
+               │       │  lighting_sh                 │
+               │       │      (trained weights;       │
+               │       │       not updated at         │
+               │       │       inference time)        │
+               │       └─────┬─────────┬───────┬──────┘
+               │             ▼         ▼       ▼
+               │          albedo   roughness  lighting_sh
+               │             │         │       │
+               └───────────┐ │         │       │
+                           ▼ ▼         ▼       ▼
+                        ┌──────────────────────────┐
+                        │       Compositor         │
+                        │  combines mesh + maps    │
+                        │  + (predicted or user)   │
+                        │  lighting → final scene  │
+                        └────────────┬─────────────┘
+                                     ▼
+                                   Scene
+```
+
+**Notes that apply to both variants:**
+- The **sketch is an input** drawn by the user; it is *never* derived from the prompt. It feeds two paths in parallel: the mesh-source pipeline (Gemini→Trellis or in-house sketch→mesh), AND the U-Net inside the Trained PBR Model.
+- **CLIP only processes the prompt.** It produces a 512-dim text feature that gets injected at the U-Net's bottleneck. Same frozen CLIP weights as during training.
+- **Qwen does NOT run at inference.** It was a training-data preprocessing step (Pipeline 1). Once the model is trained, only CLIP + U-Net are needed.
 
 **Comparison**
 - **Variant 1**: external dependency (Gemini, Trellis).

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Runs once, offline.
    └─────┬─────────┬─────────┬────────┘              └─────────────────┬────────────────┘
          │         │         │                                         │
          ▼         ▼         ▼                                         ▼
-       albedo   roughness  lighting_sh                              render
+       albedo   roughness  lighting_sh                              render (.png)
      (B,3,H,W) (B,1,H,W)  (B, 9 floats)                          (B,3,H,W)
 
    Loss:  L_albedo + λ₁·L_roughness + λ₂·L_lighting     Loss:  L_render  (MSE)

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ Runs once, offline.
    │    prompt.txt                │   │                                 │
    │    metadata.json["text"]     │   │                                 │
    └──────────────────────────────┘   └─────────────────────────────────┘
-                  │                             │
-                  ▼                             ▼
-         (no new files —                     sketch.png
-          existing prompt.txt
-          and metadata are
-          updated in place)
+                  │                                   │
+                  --------------------------------------                     
+                                    |
+                                    ▼
+                                sketch.png 
+         
 
    Both branches run on the same per-sample folder. Qwen and Stage 2 are
    independent — neither depends on the other's output.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Runs once, offline.
          │         │         │                                         │
          ▼         ▼         ▼                                         ▼
        albedo   roughness  lighting_sh                              render (.png)
-     (B,3,H,W) (B,1,H,W)  (B, 9 floats)                          (B,3,H,W)
+     (B,3,H,W) (B,1,H,W)  (B, 9 floats)                              (B,3,H,W)
 
    Loss:  L_albedo + λ₁·L_roughness + λ₂·L_lighting     Loss:  L_render  (MSE)
                             (all MSE)


### PR DESCRIPTION
README-only update. No code touched. Adds Qwen2-VL-7B (issue #38) and CLIP (issue #32) to the Pipelines 1–3 diagrams so the architecture story is accurate post-merge of #34 and (eventually) #38.

## What changed

- **Pipeline 1**: new Qwen2-VL-7B box between Stage 1 and Stage 2, captioning render.png on DF3D samples (per-sample, not per-garment).
- **Pipeline 2**: CLIP shown inside the Neural Network box (frozen, prompt → 512-dim feature). Same place in both Variant A and B.
- **Pipeline 3**: CLIP shown inside the Trained PBR Model box. Note added that Qwen does NOT run at inference — it was a training-data preprocessing step.

## Why a separate, README-only PR

Per Acar's request: keep the diagram-update diff isolated from any code change so it's easy to review and merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)