### PR TITLE
feat(#38): Qwen2-VL per-sample render captions for DF3D

### DIFF
--- a/pbr_model/postprocess_df3d_captions.py
+++ b/pbr_model/postprocess_df3d_captions.py
@@ -66,11 +66,13 @@ def _load_model(device: str):
     print(f"[qwen] loading {model_id} on {device}...")
     processor = AutoProcessor.from_pretrained(model_id)
     dtype = torch.bfloat16 if device == "cuda" else torch.float32
+    # Avoid device_map (needs `accelerate`); do .to(device) explicitly so the
+    # script works with a minimal transformers + torch install.
     model = Qwen2VLForConditionalGeneration.from_pretrained(
         model_id,
         torch_dtype=dtype,
-        device_map=device,
     )
+    model = model.to(device)
     model.eval()
     return processor, model
 

--- a/pbr_model/postprocess_df3d_captions.py
+++ b/pbr_model/postprocess_df3d_captions.py
@@ -1,0 +1,247 @@
+"""Per-sample Qwen2-VL captions for rendered DF3D samples (issue #38).
+
+Walks ``dataset/<bucket>/.../sample_*/render.png``, runs Qwen2-VL-7B on
+each render, and writes a 1–2 sentence caption capturing color, pattern,
+fabric type, lighting direction, and camera angle.
+
+Each sample's per-sample ``metadata.json`` is updated in place:
+- ``text`` field rewritten to the new caption + a photogrammetry tag
+- ``vlm_caption_at`` timestamp added (used for idempotency)
+- ``prompt.txt`` rewritten to match
+
+Why this replaces PR #39's BLIP captions:
+PR #39 captioned the **flat UV unwrap** PNGs, not the rendered scene.
+Audit of the 1,212 produced captions found ~13 % hallucinations —
+"holes", "torn", "broken" — coming from BLIP misinterpreting UV seams.
+This script captions the **rendered image** instead, so the VLM sees
+the cloth the way a viewer would.
+
+Why per-sample, not per-garment:
+Per-garment captions miss the per-sample variation in lighting, camera
+angle, and visible folds. A single garment renders multiple samples,
+each with different illumination — per-sample captures that signal.
+
+Designed for a GPU node (VALAR). ~14 GB model, ~1 sec/image on A100.
+
+Usage::
+
+    # caption all DF3D samples (default)
+    python -m pbr_model.postprocess_df3d_captions
+
+    # also caption manual + procedural samples
+    python -m pbr_model.postprocess_df3d_captions --include df3d,manual,procedural
+
+    # recaption everything (override idempotency)
+    python -m pbr_model.postprocess_df3d_captions --force
+
+    # smoke test on a handful of samples first
+    python -m pbr_model.postprocess_df3d_captions --limit 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+
+
+PHOTOGRAMMETRY_TAG = "photogrammetry-scanned fabric"
+CAPTION_PROMPT = (
+    "Describe this rendered cloth garment in 1-2 short sentences. Include "
+    "color, dominant pattern, fabric type if visible, key design features "
+    "(buttons, seams, neckline), lighting direction, and the camera angle. "
+    "Do not say it is a render or mention the background."
+)
+
+
+def _load_model(device: str):
+    import torch
+    from transformers import AutoProcessor, Qwen2VLForConditionalGeneration
+
+    model_id = "Qwen/Qwen2-VL-7B-Instruct"
+    print(f"[qwen] loading {model_id} on {device}...")
+    processor = AutoProcessor.from_pretrained(model_id)
+    dtype = torch.bfloat16 if device == "cuda" else torch.float32
+    model = Qwen2VLForConditionalGeneration.from_pretrained(
+        model_id,
+        torch_dtype=dtype,
+        device_map=device,
+    )
+    model.eval()
+    return processor, model
+
+
+def _caption_one(image, processor, model, device: str) -> str:
+    import torch
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": image},
+                {"type": "text", "text": CAPTION_PROMPT},
+            ],
+        }
+    ]
+    text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    inputs = processor(text=[text], images=[image], padding=True, return_tensors="pt").to(device)
+    with torch.no_grad():
+        out_ids = model.generate(**inputs, max_new_tokens=80, do_sample=False)
+    out_text = processor.batch_decode(
+        out_ids[:, inputs.input_ids.shape[1]:],
+        skip_special_tokens=True,
+    )[0]
+    return out_text.strip()
+
+
+def _iter_sample_dirs(repo_root: Path, buckets: list[str]) -> list[Path]:
+    """Find every sample_*/ directory across the chosen buckets."""
+    dirs: list[Path] = []
+    for bucket in buckets:
+        pattern = str(repo_root / "dataset" / bucket / "**" / "sample_*")
+        for path in glob.glob(pattern, recursive=True):
+            p = Path(path)
+            if p.is_dir() and (p / "render.png").exists() and (p / "metadata.json").exists():
+                dirs.append(p)
+    return sorted(dirs)
+
+
+def _build_text_field(caption: str, bucket: str) -> str:
+    """Compose the metadata['text'] string.
+
+    For df3d we append the photogrammetry tag so CLIP can still
+    distinguish DF3D samples from procedural/manual ones. For other
+    buckets the caption stands alone.
+    """
+    caption = caption.rstrip(".") + "."
+    if bucket == "df3d":
+        return f"{caption} {PHOTOGRAMMETRY_TAG}"
+    return caption
+
+
+def _bucket_for_sample(sample_dir: Path) -> str:
+    """Infer bucket from sample path: dataset/<bucket>/..."""
+    parts = sample_dir.parts
+    if "dataset" in parts:
+        i = parts.index("dataset")
+        if i + 1 < len(parts):
+            return parts[i + 1]
+    return "unknown"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--include", default="df3d",
+        help="comma-separated buckets to caption (default: df3d). "
+             "Example: --include df3d,manual,procedural",
+    )
+    parser.add_argument(
+        "--force", action="store_true",
+        help="recaption samples that already have a 'vlm_caption_at' timestamp",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=0,
+        help="cap the number of NEW captions written this run (0 = no cap). "
+             "Idempotent skips don't count against the limit.",
+    )
+    parser.add_argument(
+        "--repo-root", default=None,
+        help="repo root override (default: cwd)",
+    )
+    parser.add_argument(
+        "--checkpoint-every", type=int, default=10,
+        help="how often to print progress (default: every 10 captions)",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else Path.cwd()
+    buckets = [b.strip() for b in args.include.split(",") if b.strip()]
+
+    print(f"[qwen] repo_root = {repo_root}")
+    print(f"[qwen] buckets   = {buckets}")
+    print(f"[qwen] force     = {args.force}")
+    print(f"[qwen] limit     = {args.limit if args.limit else 'unlimited'}")
+
+    sample_dirs = _iter_sample_dirs(repo_root, buckets)
+    if not sample_dirs:
+        sys.exit(f"[qwen] no sample directories found under dataset/{{{','.join(buckets)}}}/.../sample_*")
+    print(f"[qwen] found {len(sample_dirs)} candidate sample dirs")
+
+    try:
+        import torch
+    except ImportError:
+        sys.exit("[qwen] torch not installed — pip install torch transformers Pillow")
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"[qwen] device = {device}")
+    if device == "cpu":
+        print("[qwen] WARNING: no CUDA. Qwen2-VL on CPU is impractically slow.")
+
+    from PIL import Image
+    processor, model = _load_model(device)
+
+    new_count = 0
+    skipped_idempotent = 0
+    errors = 0
+
+    for i, sample_dir in enumerate(sample_dirs):
+        meta_path = sample_dir / "metadata.json"
+        render_path = sample_dir / "render.png"
+
+        try:
+            with open(meta_path) as f:
+                metadata = json.load(f)
+        except Exception as e:
+            print(f"[qwen] skip (bad metadata.json) {sample_dir}: {e}")
+            errors += 1
+            continue
+
+        if metadata.get("vlm_caption_at") and not args.force:
+            skipped_idempotent += 1
+            continue
+
+        try:
+            image = Image.open(render_path).convert("RGB")
+            caption = _caption_one(image, processor, model, device)
+        except Exception as e:
+            print(f"[qwen] error captioning {sample_dir}: {e}")
+            errors += 1
+            continue
+
+        bucket = _bucket_for_sample(sample_dir)
+        text = _build_text_field(caption, bucket)
+
+        metadata["text"] = text
+        metadata["vlm_caption"] = caption
+        metadata["vlm_caption_at"] = _dt.datetime.now(_dt.timezone.utc).isoformat()
+        metadata["vlm_caption_model"] = "Qwen/Qwen2-VL-7B-Instruct"
+
+        with open(meta_path, "w") as f:
+            json.dump(metadata, f, indent=2)
+        with open(sample_dir / "prompt.txt", "w") as f:
+            f.write(text + "\n")
+
+        new_count += 1
+        if new_count % args.checkpoint_every == 0 or new_count <= 3:
+            print(f"[qwen] {new_count} captioned ({skipped_idempotent} skipped, {errors} errors)")
+            print(f"       {sample_dir.relative_to(repo_root)}")
+            print(f"       -> {caption[:140]}")
+
+        if args.limit and new_count >= args.limit:
+            print(f"[qwen] reached --limit {args.limit}, stopping")
+            break
+
+    print(
+        f"[qwen] done. {new_count} new captions, "
+        f"{skipped_idempotent} skipped (idempotent), {errors} errors."
+    )
+
+
+if __name__ == "__main__":
+    # Allow `python pbr_model/postprocess_df3d_captions.py` from repo root (without -m).
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    main()


### PR DESCRIPTION
Implements issue #38 — per-sample VLM captions on rendered DF3D samples.

## What this replaces

PR #39 added BLIP captioning, but ran it on the **flat UV unwrap PNGs**, not the rendered scene. Audit of the 1,212 produced captions found ~13 % hallucinations ("torn", "holes", "broken") — BLIP was misinterpreting UV seam patterns. PR #48 disabled the BLIP captions from being injected into prompts. This PR provides the proper replacement.

## What changes

New script: `pbr_model/postprocess_df3d_captions.py`.

It walks `dataset/<bucket>/.../sample_*/render.png` for the configured buckets (default: df3d), runs Qwen2-VL-7B-Instruct on each rendered image, and writes a 1–2 sentence caption that captures:

- Color, dominant pattern
- Fabric type if visible
- Key design features (buttons, seams, neckline)
- Lighting direction
- Camera angle

Each per-sample `metadata.json` gets updated in place:
- `text` → new caption (+ `photogrammetry-scanned fabric` suffix for df3d, so CLIP keeps the bucket signal)
- `vlm_caption` → raw Qwen output
- `vlm_caption_at` → ISO timestamp
- `vlm_caption_model` → model ID

`prompt.txt` is rewritten to match.

## Idempotency + recovery

- Resumable: a sample with `vlm_caption_at` is skipped unless `--force` is passed
- Progress printed every `--checkpoint-every` (default: 10) captions
- Errors on individual samples are logged and skipped, not fatal

## CLI

```bash
# default: caption all df3d samples
python -m pbr_model.postprocess_df3d_captions

# smoke test on 5 samples
python -m pbr_model.postprocess_df3d_captions --limit 5

# expand to other buckets
python -m pbr_model.postprocess_df3d_captions --include df3d,manual,procedural

# recaption everything
python -m pbr_model.postprocess_df3d_captions --force
```

## Why per-sample (not per-garment)

Per-garment captions miss the per-sample variation in lighting, camera angle, and visible folds. A single garment renders multiple samples; each has different illumination. Per-sample captions capture that.

Earlier proposal was per-garment (590 calls, ~10 min); per-sample is ~10,000 calls × ~1 sec/img on A100 = ~3 hours. One-time cost per dataset version — worth it.

## Why Qwen2-VL-7B-Instruct (vs BLIP / Florence / LLaVA)

- SOTA among open-source VLMs at the 7 B class for instruction-following
- Detailed captions, follows the prompt's structure ("color, pattern, fabric, lighting, angle")
- Free, runs on a single GPU (~14 GB VRAM)
- Available via `transformers` (`Qwen/Qwen2-VL-7B-Instruct`)

## No changes to render_loop.py or the loader

Captions go into `metadata.json["text"]` — the field the data loader already reads. No model or training-pipeline change.

## What's deliberately NOT in this PR

- Deletion of the old BLIP captioning script (`scripts/caption_textures.py`) — leaving it as orphan code; PR #48's note about it stands
- Deletion of the old `meshes/df3d/captions.json` BLIP output — same reason
- Wiring captions into prompts via render_loop.py — captions update the per-sample metadata directly, so render_loop.py needs no change

## Test plan

VALAR:
- [ ] `python -m pbr_model.postprocess_df3d_captions --limit 5` runs without crashing on the first 5 DF3D samples after Stage 1
- [ ] Inspect the 5 updated `metadata.json` files — `text` field contains a coherent 1–2 sentence caption (color, pattern, design features visible)
- [ ] Re-run the same command — all 5 are skipped (idempotency works)
- [ ] Run `--force --limit 5` — same 5 samples recaptioned
- [ ] Full run: `python -m pbr_model.postprocess_df3d_captions` — completes in ~3 hours on A100 for ~10,000 samples

Closes #38.